### PR TITLE
Fixed NPE in FileDownloader when no target file is given

### DIFF
--- a/docs/src/docs/gettingstarted/system-proxy.adoc
+++ b/docs/src/docs/gettingstarted/system-proxy.adoc
@@ -9,7 +9,7 @@ There are three ways for setting up a proxy for your test run environment.
 
 == Command line (recommended)
 To setup a proxy for the whole system, including the build environment (Maven, Gradle), the JVM and Testerra, the recommended way is to pass it by command line arguments like
-[source]
+[source,bash]
 ----
 gradle test -Dhttps.proxyHost=your-proxy-host.com -Dhttps.proxyPort=8080
 ----
@@ -39,7 +39,7 @@ The system proxy can be accessed by <<Proxy Utilities>>
 
 == Implicit setup (not recommended)
 Since Java 11, it is possible to pass the system's preconfigured proxy into the JVM.
-[source]
+[source,bash]
 ----
 gradle test -Djava.net.useSystemProxies=true
 ----

--- a/docs/src/docs/gettingstarted/system-proxy.adoc
+++ b/docs/src/docs/gettingstarted/system-proxy.adoc
@@ -36,3 +36,12 @@ http.proxyPassword=
 == Access the system proxy URL
 
 The system proxy can be accessed by <<Proxy Utilities>>
+
+== Implicit setup (not recommended)
+Since Java 11, it is possible to pass the system's preconfigured proxy into the JVM.
+[source]
+----
+gradle test -Djava.net.useSystemProxies=true
+----
+This affects all Java internal network connections which uses `ProxySelector`, but it will not set the environment variables and are transparent to <<Proxy Utilities>> and any <<Browser capabilities>>.
+

--- a/docs/src/docs/utilities/file-downloader.adoc
+++ b/docs/src/docs/utilities/file-downloader.adoc
@@ -2,7 +2,7 @@
 
 == FileDownloader
 
-The `FileDownloader` utility provides methods for downloading resources from web sites.
+The `FileDownloader` utility provides methods for downloading resources from web sites. It uses the <<Using a proxy,default proxy configuration>>.
 
 .Basic example how to use the FileDownloader
 [source,java]

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/utils/FileDownloader.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/utils/FileDownloader.java
@@ -28,7 +28,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
-import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.net.URL;
 import java.net.URLConnection;
@@ -42,7 +41,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Utility class for downloading files to executing host
+ * Utility class for downloading files to executing host.
  * <p>
  * Date: 14.12.2015
  * Time: 07:35
@@ -90,32 +89,30 @@ public class FileDownloader {
      * @param downloadLocation     String Download target location
      * @param imitateCookies       boolean Imitate cookies?
      * @param trustAllCertificates boolean Accept all certificates?
+     * @deprecated Use {@link #FileDownloader()} instead
      */
-    public FileDownloader(final String downloadLocation, final boolean imitateCookies,
-                          boolean trustAllCertificates) {
+    public FileDownloader(
+            String downloadLocation,
+            boolean imitateCookies,
+            boolean trustAllCertificates
+    ) {
         this.downloadLocation = downloadLocation;
         this.imitateCookies = imitateCookies;
         this.trustAllCertificates = trustAllCertificates;
-
-        final URL systemHttpProxyUrl = ProxyUtils.getSystemHttpProxyUrl();
-        if (systemHttpProxyUrl != null) {
-            this.proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(systemHttpProxyUrl.getHost(), systemHttpProxyUrl.getPort()));
-        }
     }
 
     /**
      * Instantiate FileDownloader
      *
      * @param downloadLocation String
+     * @deprecated
      */
     public FileDownloader(final String downloadLocation) {
         this.downloadLocation = downloadLocation;
     }
 
-    /**
-     * Instantiate FileDownloader
-     */
     public FileDownloader() {
+
     }
 
     /**
@@ -294,7 +291,8 @@ public class FileDownloader {
             String cookieString,
             boolean useSecondConnection
     ) throws IOException {
-        LOGGER.info("Download " + url + " to " + targetFile.getAbsolutePath());
+
+        LOGGER.info("Start downloading " + url);
 
         String targetFileName = "";
         URLConnection connection = openConnection(url, proxy, timeoutMS, trustAll, cookieString, sslSocketFactory);
@@ -319,8 +317,10 @@ public class FileDownloader {
             targetFile = FileUtils.getFile(this.getDownloadLocation() + "/" + targetFileName);
         }
 
+        LOGGER.info("Downloaded " + url + " to " + targetFile.getAbsolutePath());
+
         FileUtils.copyInputStreamToFile(inputStream, targetFile);
-        
+
         synchronized (downloadList) {
             downloadList.add(targetFile.getAbsolutePath());
         }

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/WebDriverProxyUtils.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/WebDriverProxyUtils.java
@@ -114,7 +114,9 @@ public class WebDriverProxyUtils {
      * @return Proxy settings without socks proxy based on {@link ProxyUtils#getSystemHttpsProxyUrl()}.
      */
     public Proxy getDefaultHttpProxy() {
-        Proxy proxy = createHttpProxyFromUrl(ProxyUtils.getSystemHttpsProxyUrl());
+        URL systemProxyUrl = ProxyUtils.getSystemHttpsProxyUrl();
+        if (systemProxyUrl == null) systemProxyUrl = ProxyUtils.getSystemHttpProxyUrl();
+        Proxy proxy = createHttpProxyFromUrl(systemProxyUrl);
         proxy.setNoProxy(PropertyManager.getProperty("https.nonProxyHosts"));
         return proxy;
     }


### PR DESCRIPTION
This PR fixes NPE in FileDownloader when no target file is given.
It also improves the proxy setup for testing environments and updates the proxy setup documentation.