### PR TITLE
Initialize SessionContext in abstract WebDriverFactory

### DIFF
--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/report/model/context/SessionContext.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/report/model/context/SessionContext.java
@@ -64,8 +64,8 @@ public class SessionContext extends AbstractContext implements SynchronizableCon
         return this;
     }
 
-    public String getRemoteSessionId() {
-        return remoteSessionId;
+    public Optional<String> getRemoteSessionId() {
+        return Optional.ofNullable(remoteSessionId);
     }
 
     public SessionContext setRemoteSessionId(String sessionId) {

--- a/driver-ui-desktop/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/DesktopWebDriverFactory.java
+++ b/driver-ui-desktop/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/DesktopWebDriverFactory.java
@@ -34,26 +34,21 @@ import eu.tsystems.mms.tic.testframework.exceptions.SystemException;
 import eu.tsystems.mms.tic.testframework.internal.Defaults;
 import eu.tsystems.mms.tic.testframework.internal.Flags;
 import eu.tsystems.mms.tic.testframework.internal.StopWatch;
-import eu.tsystems.mms.tic.testframework.internal.TimingInfo;
 import eu.tsystems.mms.tic.testframework.internal.utils.DriverStorage;
-import eu.tsystems.mms.tic.testframework.internal.utils.TimingInfosCollector;
 import eu.tsystems.mms.tic.testframework.logging.Loggable;
 import eu.tsystems.mms.tic.testframework.model.NodeInfo;
 import eu.tsystems.mms.tic.testframework.report.model.context.SessionContext;
 import eu.tsystems.mms.tic.testframework.report.utils.ExecutionContextUtils;
 import eu.tsystems.mms.tic.testframework.sikuli.SikuliWebDriver;
 import eu.tsystems.mms.tic.testframework.transfer.ThrowablePackedResponse;
-import eu.tsystems.mms.tic.testframework.useragents.BrowserInformation;
 import eu.tsystems.mms.tic.testframework.useragents.UserAgentConfig;
 import eu.tsystems.mms.tic.testframework.utils.FileUtils;
 import eu.tsystems.mms.tic.testframework.utils.StringUtils;
 import eu.tsystems.mms.tic.testframework.utils.Timer;
 import eu.tsystems.mms.tic.testframework.utils.TimerUtils;
-import eu.tsystems.mms.tic.testframework.utils.WebDriverUtils;
 import eu.tsystems.mms.tic.testframework.webdrivermanager.desktop.WebDriverMode;
 import java.io.File;
 import java.lang.reflect.Constructor;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Date;
 import java.util.HashMap;
@@ -86,7 +81,7 @@ import org.openqa.selenium.support.events.EventFiringWebDriver;
 
 public class DesktopWebDriverFactory extends WebDriverFactory<DesktopWebDriverRequest> implements Loggable {
 
-    public static final TimingInfosCollector STARTUP_TIME_COLLECTOR = new TimingInfosCollector();
+    //public static final TimingInfosCollector STARTUP_TIME_COLLECTOR = new TimingInfosCollector();
 
     private static File phantomjsFile = null;
 
@@ -299,11 +294,7 @@ public class DesktopWebDriverFactory extends WebDriverFactory<DesktopWebDriverRe
             DesiredCapabilities capabilities,
             SessionContext sessionContext
     ) {
-        String sessionKey = desktopWebDriverRequest.getSessionKey();
         final String browser = desktopWebDriverRequest.getBrowser();
-
-        org.apache.commons.lang3.time.StopWatch sw = new org.apache.commons.lang3.time.StopWatch();
-        sw.start();
 
         /*
          * Remote or local
@@ -334,34 +325,14 @@ public class DesktopWebDriverFactory extends WebDriverFactory<DesktopWebDriverRe
         }
 
         /*
-        Log session id
-         */
-        String remoteSessionId = WebDriverUtils.getSessionId(newDriver);
-        sessionContext.setRemoteSessionId(remoteSessionId);
-        /*
         Log User Agent and executing host
          */
-        NodeInfo nodeInfo = null;
-        if (remoteAddress != null) {
+        if (remoteAddress != null && newDriver instanceof RemoteWebDriver) {
             DesktopWebDriverUtils utils = new DesktopWebDriverUtils();
-            nodeInfo = utils.getNodeInfo(remoteAddress, remoteSessionId);
+            NodeInfo nodeInfo = utils.getNodeInfo(remoteAddress, ((RemoteWebDriver) newDriver).getSessionId().toString());
             sessionContext.setNodeInfo(nodeInfo);
         }
-        sw.stop();
-
-        BrowserInformation browserInformation = WebDriverManagerUtils.getBrowserInformation(newDriver);
-        sessionContext.setActualBrowserName(browserInformation.getBrowserName());
-        sessionContext.setActualBrowserVersion(browserInformation.getBrowserVersion());
-        log().info(String.format(
-                "Started %s (sessionKey=%s, sessionId=%s, node=%s, userAgent=%s) in %s",
-                newDriver.getClass().getSimpleName(),
-                sessionKey,
-                remoteSessionId,
-                (nodeInfo != null ? nodeInfo.toString() : "local webdriver"),
-                browserInformation.getBrowserName() + ":" + browserInformation.getBrowserVersion(),
-                sw.toString()
-        ));
-        STARTUP_TIME_COLLECTOR.add(new TimingInfo("SessionStartup", "", sw.getTime(TimeUnit.MILLISECONDS), System.currentTimeMillis()));
+        //STARTUP_TIME_COLLECTOR.add(new TimingInfo("SessionStartup", "", sw.getTime(TimeUnit.MILLISECONDS), System.currentTimeMillis()));
 
         return newDriver;
     }

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/WebDriverFactory.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/WebDriverFactory.java
@@ -24,11 +24,13 @@
 import eu.tsystems.mms.tic.testframework.logging.Loggable;
 import eu.tsystems.mms.tic.testframework.report.model.context.SessionContext;
 import eu.tsystems.mms.tic.testframework.report.utils.ExecutionContextController;
+import eu.tsystems.mms.tic.testframework.useragents.BrowserInformation;
 import eu.tsystems.mms.tic.testframework.utils.ObjectUtils;
-import eu.tsystems.mms.tic.testframework.utils.StringUtils;
-import java.net.MalformedURLException;
+import org.apache.commons.lang3.time.StopWatch;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.remote.SessionId;
 import org.openqa.selenium.support.events.EventFiringWebDriver;
 
 public abstract class WebDriverFactory<R extends AbstractWebDriverRequest> implements Loggable {
@@ -69,7 +71,29 @@ public abstract class WebDriverFactory<R extends AbstractWebDriverRequest> imple
         /*
         create the web driver session
          */
+        StopWatch sw = new StopWatch();
+        sw.start();
         WebDriver rawDriver = getRawWebDriver(finalRequest, preparedCaps, sessionContext);
+        sw.stop();
+
+        BrowserInformation browserInformation = WebDriverManagerUtils.getBrowserInformation(rawDriver);
+
+        if (rawDriver instanceof RemoteWebDriver) {
+            SessionId sessionId = ((RemoteWebDriver) rawDriver).getSessionId();
+            sessionContext.setRemoteSessionId(sessionId.toString());
+        }
+
+        sessionContext.setActualBrowserName(browserInformation.getBrowserName());
+        sessionContext.setActualBrowserVersion(browserInformation.getBrowserVersion());
+        log().info(String.format(
+                "Started %s (sessionKey=%s, sessionId=%s, node=%s, userAgent=%s) in %s",
+                rawDriver.getClass().getSimpleName(),
+                sessionContext.getSessionKey(),
+                sessionContext.getRemoteSessionId().orElse("(local)"),
+                sessionContext.getNodeInfo().map(Object::toString).orElse("(unknown)"),
+                browserInformation.getBrowserName() + ":" + browserInformation.getBrowserVersion(),
+                sw.toString()
+        ));
 
         /*
         wrap the driver with the proxy

--- a/report-model/src/main/java/eu/tsystems/mms/tic/testframework/adapters/ContextExporter.java
+++ b/report-model/src/main/java/eu/tsystems/mms/tic/testframework/adapters/ContextExporter.java
@@ -23,7 +23,6 @@ package eu.tsystems.mms.tic.testframework.adapters;
 
 import com.google.common.net.MediaType;
 import com.google.gson.Gson;
-import eu.tsystems.mms.tic.testframework.annotations.Fails;
 import eu.tsystems.mms.tic.testframework.logging.Loggable;
 import eu.tsystems.mms.tic.testframework.report.Report;
 import eu.tsystems.mms.tic.testframework.report.TesterraListener;
@@ -64,7 +63,6 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -534,7 +532,7 @@ public class ContextExporter implements Loggable {
         apply(buildContextValues(sessionContext), builder::setContextValues);
         //apply(sessionContext.getSessionKey(), builder::setSessionKey);
         //apply(sessionContext.getProvider(), builder::setProvider);
-        apply(sessionContext.getRemoteSessionId(), builder::setSessionId);
+        sessionContext.getRemoteSessionId().ifPresent(builder::setSessionId);
         sessionContext.getVideo().ifPresent(video -> {
             Optional<File.Builder> optional = Optional.ofNullable(buildVideo(video));
             optional.ifPresent(fileBuilder -> builder.setVideoId(fileBuilder.getId()));


### PR DESCRIPTION
# Description

This PR moves the code for initializing a `SessionContext` to the abstract `WebDriverFactory`. That improves error robustness when reading `SessionContext.getRemoteSessionId()`