### PR TITLE
Feature/added browser cap hints

### DIFF
--- a/docs/src/docs/browser-caps.adoc
+++ b/docs/src/docs/browser-caps.adoc
@@ -1,4 +1,5 @@
 = Browser capabilities
 
-include::browsercaps/basic-caps.adoc[leveloffset=+1]
+include::browsercaps/global-caps.adoc[leveloffset=+1]
+include::browsercaps/local-caps.adoc[leveloffset=+1]
 include::browsercaps/proxy-setup.adoc[leveloffset=+1]

--- a/docs/src/docs/browsercaps/global-caps.adoc
+++ b/docs/src/docs/browsercaps/global-caps.adoc
@@ -17,16 +17,17 @@ class MyTest extends TesterraTest {
 }
 ----
 
-== Setting local capabilities
+[IMPORTANT]
+====
+Do NOT set browser capabilities with WebDriverManager like:
 
-A local defined capability means its only available in the current test execution (current TestNG testmethod).
-
-[source,java]
+[source, java]
 ----
-WebDriverManager.addThreadCapability(CapabilityType.ACCEPT_INSECURE_CERTS, true);
+FirefoxOptions options = new FirefoxOptions();
+options.addPreference("intl.accept_languages", "de-DE");
+// This cannot be merged correctly!
+WebDriverManager.setGlobalExtraCapability(FirefoxOptions.FIREFOX_OPTIONS, options);
 ----
 
-[NOTE]
-=====
-Have a look into <<Useful browser capabilities>> for specific browser options.
-=====
+====
+

--- a/docs/src/docs/browsercaps/local-caps.adoc
+++ b/docs/src/docs/browsercaps/local-caps.adoc
@@ -1,0 +1,13 @@
+= Setting local capabilities
+
+A local defined capability means its only available in the current test execution (current TestNG testmethod).
+
+[source,java]
+----
+WebDriverManager.addThreadCapability(CapabilityType.ACCEPT_INSECURE_CERTS, true);
+----
+
+[NOTE]
+=====
+Have a look into <<Useful browser capabilities>> for specific browser options.
+=====

--- a/docs/src/docs/browsercaps/proxy-setup.adoc
+++ b/docs/src/docs/browsercaps/proxy-setup.adoc
@@ -2,7 +2,7 @@
 
 If you want that the browser uses a proxy for the SUT, you can just configure that by default Selenium capabilites.
 
-IMPORTANT: Make sure that your WebDriver supports the Proxy-Capability. Some WebDrivers, like the MicrosoftWebDriver, don't (see https://docs.microsoft.com/en-us/microsoft-edge/webdriver#w3c-webdriver[Edge WebDriver Capabilities]).
+IMPORTANT: Make sure that your WebDriver supports the Proxy-Capability. For example the MicrosoftWebDriver for Legacy Edge does not support proxy setup (see https://docs.microsoft.com/en-us/archive/microsoft-edge/legacy/developer/webdriver/[Edge WebDriver Capabilities]).
 
 NOTE: If you want to setup a proxy for the runtime environment but the browser, you have to follow the instructions at <<Using a proxy>>
 

--- a/driver-ui-desktop/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/DesktopWebDriverFactory.java
+++ b/driver-ui-desktop/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/DesktopWebDriverFactory.java
@@ -47,14 +47,6 @@ import eu.tsystems.mms.tic.testframework.utils.StringUtils;
 import eu.tsystems.mms.tic.testframework.utils.Timer;
 import eu.tsystems.mms.tic.testframework.utils.TimerUtils;
 import eu.tsystems.mms.tic.testframework.webdrivermanager.desktop.WebDriverMode;
-import java.io.File;
-import java.lang.reflect.Constructor;
-import java.net.URL;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.TreeMap;
-import java.util.concurrent.TimeUnit;
 import net.anthavio.phanbedder.Phanbedder;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.Dimension;
@@ -78,6 +70,14 @@ import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.safari.SafariDriver;
 import org.openqa.selenium.safari.SafariOptions;
 import org.openqa.selenium.support.events.EventFiringWebDriver;
+
+import java.io.File;
+import java.lang.reflect.Constructor;
+import java.net.URL;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 public class DesktopWebDriverFactory extends WebDriverFactory<DesktopWebDriverRequest> implements Loggable {
 
@@ -356,8 +356,10 @@ public class DesktopWebDriverFactory extends WebDriverFactory<DesktopWebDriverRe
             case Browsers.firefox:
                 FirefoxOptions firefoxOptions = new FirefoxOptions();
                 if (capabilities.getCapabilityNames().contains(FirefoxOptions.FIREFOX_OPTIONS)) {
-                    final TreeMap predefinedFirefoxOptions = (TreeMap) capabilities.getCapability(FirefoxOptions.FIREFOX_OPTIONS);
-                    predefinedFirefoxOptions.forEach((s, o) -> firefoxOptions.setCapability(s.toString(), o));
+                    log().warn("Do not add FirefoxOptions via 'WebDriverManager.setGlobalExtraCapability(..)'! It will be ignored.");
+                    log().warn("Use 'WebDriverManager.setUserAgentConfig(Browsers.firefox, (FirefoxConfig) options -> {...}' instead.");
+//                    final TreeMap predefinedFirefoxOptions = (TreeMap) capabilities.getCapability(FirefoxOptions.FIREFOX_OPTIONS);
+//                    predefinedFirefoxOptions.forEach((s, o) -> firefoxOptions.setCapability(s.toString(), o));
                 }
                 if (userAgentConfig != null) {
                     userAgentConfig.configure(firefoxOptions);
@@ -380,8 +382,10 @@ public class DesktopWebDriverFactory extends WebDriverFactory<DesktopWebDriverRe
             case Browsers.chromeHeadless:
                 ChromeOptions chromeOptions = new ChromeOptions();
                 if (capabilities.getCapabilityNames().contains(ChromeOptions.CAPABILITY)) {
-                    final TreeMap predefinedChromeOptions = (TreeMap) capabilities.getCapability(ChromeOptions.CAPABILITY);
-                    predefinedChromeOptions.forEach((s, o) -> chromeOptions.setCapability(s.toString(), o));
+                    log().warn("Do not add ChromeOptions via 'WebDriverManager.setGlobalExtraCapability(..)'! It will be ignored.");
+                    log().warn("Use 'WebDriverManager.setUserAgentConfig(Browsers.chrome, (ChromeConfig) options -> {...}' instead.");
+//                    final TreeMap predefinedChromeOptions = (TreeMap) capabilities.getCapability(ChromeOptions.CAPABILITY);
+//                    predefinedChromeOptions.forEach((s, o) -> chromeOptions.setCapability(s.toString(), o));
                 }
 
                 if (userAgentConfig != null) {


### PR DESCRIPTION
# Description

I removed the workaround to add browser options via `WebDriverManager.setGlobalExtraCapability(FirefoxOptions.FIREFOX_OPTIONS, firefoxOptions);` because it does not work correctly or creates exceptions while merging FirefoxOptions. 

To publish this important issue I updated documentation and added log warnings.
