### PR TITLE
[WIP] adjust xpath correction

### DIFF
--- a/driver-ui-desktop/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/internal/core/DesktopGuiElementCore.java
+++ b/driver-ui-desktop/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/internal/core/DesktopGuiElementCore.java
@@ -398,7 +398,7 @@ public class DesktopGuiElementCore implements GuiElementCore, Loggable {
             // .//input --> No corrections
             if (xpath.startsWith("/")) {
                 xpath = xpath.replaceFirst("/", "./");
-            } else if (!xpath.startsWith(".")) {
+            } else if (!xpath.startsWith(".") && !xpath.startsWith("(")) {
                 xpath = "./" + xpath;
             }
         }

--- a/driver-ui-desktop/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/internal/core/DesktopGuiElementCore.java
+++ b/driver-ui-desktop/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/internal/core/DesktopGuiElementCore.java
@@ -396,9 +396,12 @@ public class DesktopGuiElementCore implements GuiElementCore, Loggable {
             // input --> ./input
             // ./input --> No corrections
             // .//input --> No corrections
+            // (//input) --> No corrections
             if (xpath.startsWith("/")) {
                 xpath = xpath.replaceFirst("/", "./");
-            } else if (!xpath.startsWith(".") && !xpath.startsWith("(")) {
+            } else if (xpath.startsWith("(")) {
+                // do nothing with grouped xPathes
+            } else if (!xpath.startsWith(".")) {
                 xpath = "./" + xpath;
             }
         }

--- a/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/guielement/GuiElementAdditionalTests.java
+++ b/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/guielement/GuiElementAdditionalTests.java
@@ -61,5 +61,14 @@ public class GuiElementAdditionalTests extends AbstractTestSitesTest {
         LogAssertUtils.assertEntryNotInLogFile("pageobjects.GuiElement - type \"testT02_SensibleData\" on By.id: 1");
     }
 
+    @Test
+    public void testT03_GetElementsWithParenthesisInXpath() {
+        final WebDriver driver = WebDriverManager.getWebDriver();
+        GuiElement box = new GuiElement(driver, By.xpath("//div[@class='box'][1]"));
+        GuiElement subElement = box.getSubElement(By.xpath("(//input[@id='2'])"));
+
+        subElement.asserts().assertIsPresent();
+
+    }
 
 }


### PR DESCRIPTION
---
name: Pull Request for fixing issue #11 
about: Create a pull request for your changes
title: 'Bugfix issue #11 '
labels: enhancement
assignees: ''

---

# Description

Added a condition that does not prepend "./" to Xpath when trying to get subelement and selecting them by xpath which starts with opening parenthese, so the xpath remain unchanged and works properly. Added dedicated test for that in GuiElementAdditionalTests.

Fixes #11

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
