### PR TITLE
Fixing correction of xpath with parentheses in correctToRelativeXPath() in testerra2

### DIFF
--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/internal/core/AbstractWebDriverCore.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/internal/core/AbstractWebDriverCore.java
@@ -97,7 +97,9 @@ public abstract class AbstractWebDriverCore extends AbstractGuiElementCore imple
             if (xpath.startsWith("/")) {
                 xpath = xpath.replaceFirst("/", "./");
                 corrected = true;
-            } else if (!xpath.startsWith("(")) {
+            } else if (xpath.startsWith("(")) {
+                // do nothing with grouped xPathes
+            } else if (!xpath.startsWith(".")) {
                 xpath = "./" + xpath;
                 corrected = true;
             }

--- a/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/guielement/GuiElementAdditionalTests.java
+++ b/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/guielement/GuiElementAdditionalTests.java
@@ -60,5 +60,12 @@ public class GuiElementAdditionalTests extends AbstractTestSitesTest {
         LogAssertUtils.assertEntryNotInLogFile("type(\"testT02_SensibleData\")");
     }
 
+    @Test
+    public void testT03_GetElementsWithParenthesisInXpath() {
+        final WebDriver driver = getWebDriver();
+        GuiElement box = new GuiElement(driver, By.xpath("//div[@class='box'][1]"));
+        GuiElement subElement = box.getSubElement(By.xpath("(//input[@id='1'])"));
 
+        subElement.asserts().assertIsPresent();
+    }
 }


### PR DESCRIPTION
fixes for corrections of Xpath with parentheses in correctToRelativeXPath() and addition test for it

---
name: Fix for issue #11
about: Create a pull request for your changes
title: ''
labels: enhancement bugfix
assignees: ''

---

# Description

Fixed xpath correction for xpathes with parenthesis and adding a test for that.

Fixes #11 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
