### PR TITLE
Use escaped path in report-ng when accessing JAR

### DIFF
--- a/report-ng/src/main/java/eu/tsystems/mms/tic/testframework/listeners/CopyReportAppListener.java
+++ b/report-ng/src/main/java/eu/tsystems/mms/tic/testframework/listeners/CopyReportAppListener.java
@@ -75,7 +75,7 @@ public class CopyReportAppListener implements FinalizeExecutionEvent.Listener, L
                 .getCodeSource()
                 .getLocation()
                 .toURI()
-                .getPath();
+                .getRawPath();
 
         List<Path> result;
 


### PR DESCRIPTION
# Description

Previously the URI to the JAR file of report-ng was constructed using the unescaped path. This would fail if there are carecters in the path that are not valid in the path component of a URI (e.g. spaces). This pull request changes the construction of the URI to use the escaped path component and makes report-ng work with local maven repos that have spaces and other
special characters in their path.

Fixes #33 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

Tested on Windows in Git Bash and on Ubuntu 20.04.
