### PR TITLE
Fixed retrieving raw class context for MethodDetails.

### DIFF
--- a/report-ng/app/src/services/statistic-models.ts
+++ b/report-ng/app/src/services/statistic-models.ts
@@ -206,14 +206,13 @@ export class ExecutionStatistics extends Statistics {
 export class ClassStatistics extends Statistics {
     private _configStatistics = new Statistics();
     private _methodContexts:IMethodContext[] = [];
-    private _classContext:IClassContext;
-    private _classIdentifier;
+    readonly _classIdentifier;
 
-    setClassContext(classContext : IClassContext) {
-        this._classContext = classContext;
+    constructor(
+        readonly classContext:IClassContext
+    ) {
+        super();
         this._classIdentifier = classContext.testContextName || classContext.contextValues.name;
-        // this.statusConverter.separateNamespace(classContext.fullClassName).class
-        return this;
     }
 
     addMethodContext(methodContext : IMethodContext) {
@@ -224,10 +223,6 @@ export class ClassStatistics extends Statistics {
         }
         this._methodContexts.push(methodContext);
         return this;
-    }
-
-    get classContext() {
-        return this._classContext;
     }
 
     get methodContexts() {

--- a/report-ng/app/src/services/statistics-generator.ts
+++ b/report-ng/app/src/services/statistics-generator.ts
@@ -31,8 +31,6 @@ import {StatusConverter} from "./status-converter";
 import ITestContext = data.ITestContext;
 import ISuiteContext = data.ISuiteContext;
 import ISessionContext = data.ISessionContext;
-import ClassContext = data.ClassContext;
-import IClassContext = data.IClassContext;
 
 export class FailsAnnotation {
     constructor(


### PR DESCRIPTION
# Description

* Fixed back references class context for method context when retrieving method details.
* That fixes referencing the wrong class, when a method has been run multiple times in different test contexts.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
