### PR TITLE
Revert: Reading event state from MethodContext instead of TestNG. Tha…

### DIFF
--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/events/AbstractMethodEvent.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/events/AbstractMethodEvent.java
@@ -88,27 +88,15 @@ public abstract class AbstractMethodEvent {
         this.invokedMethod = invokedMethod;
         return this;
     }
-
-    /**
-     * @deprecated Use {@link #getMethodContext()} instead
-     */
     public boolean isSkipped() {
-        //return testResult.getStatus() == ITestResult.SKIP;
-        return methodContext.isSkipped();
+        return testResult.getStatus() == ITestResult.SKIP;
     }
 
-    /**
-     * @deprecated Use {@link #getMethodContext()} instead
-     */
     public boolean isFailed() {
-        return methodContext.isFailed();
+        return (!isPassed() && !isSkipped());
     }
 
-    /**
-     * @deprecated Use {@link #getMethodContext()} instead
-     */
     public boolean isPassed() {
-        //return testResult.isSuccess();
-        return methodContext.isPassed();
+        return testResult.isSuccess();
     }
 }


### PR DESCRIPTION
# Description

Bugfix for invalid `MethodContext` state which got never updated, because the underlying `MethodEndEvent` state was detected mistakenly by `MethodContext` itself instead TestNG `TestResult`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
