### PR TITLE
Added support for custom test names, which prevents the duplicate out…

### DIFF
--- a/report-model/src/main/java/eu/tsystems/mms/tic/testframework/adapters/ContextExporter.java
+++ b/report-model/src/main/java/eu/tsystems/mms/tic/testframework/adapters/ContextExporter.java
@@ -105,14 +105,29 @@ public class ContextExporter implements Loggable {
     public MethodContext.Builder buildMethodContext(eu.tsystems.mms.tic.testframework.report.model.context.MethodContext methodContext) {
         MethodContext.Builder builder = MethodContext.newBuilder();
 
-        apply(buildContextValues(methodContext), builder::setContextValues);
+        ContextValues.Builder contextValuesBuilder = buildContextValues(methodContext);
+
+
+        methodContext.getTestNgResult().ifPresent(iTestResult -> {
+            String testName = methodContext.getName();
+            String methodName = iTestResult.getMethod().getMethodName();
+            // When the context name differs from the method name
+            if (!testName.equals(methodName)) {
+                // Set the context name to the method name
+                contextValuesBuilder.setName(methodName);
+                // And the test name to the actual generated test name
+                builder.setTestName(testName);
+            }
+        });
+
+        builder.setContextValues(contextValuesBuilder);
+
         map(methodContext.getStatus(), this::getMappedStatus, builder::setResultStatus);
         map(methodContext.getMethodType(), type -> MethodType.valueOf(type.name()), builder::setMethodType);
         List<Object> parameterValues = methodContext.getParameterValues();
         for (int i = 0; i < parameterValues.size(); ++i) {
             builder.putParameters(methodContext.getParameters()[i].getName(), parameterValues.get(i).toString());
         }
-
 
         methodContext.readAnnotations()
                 // Skip TestNG annotations

--- a/report-model/src/main/java/eu/tsystems/mms/tic/testframework/report/model/Framework.java
+++ b/report-model/src/main/java/eu/tsystems/mms/tic/testframework/report/model/Framework.java
@@ -167,7 +167,7 @@ public final class Framework {
       "s\030\020 \003(\01321.data.ExecutionContext.FailureC" +
       "orridorLimitsEntry\032<\n\032FailureCorridorLim" +
       "itsEntry\022\013\n\003key\030\001 \001(\005\022\r\n\005value\030\002 \001(\005:\0028\001" +
-      "\"\331\007\n\rMethodContext\022+\n\016context_values\030\001 \001" +
+      "\"\354\007\n\rMethodContext\022+\n\016context_values\030\001 \001" +
       "(\0132\023.data.ContextValues\022%\n\013method_type\030\007" +
       " \001(\0162\020.data.MethodType\022\024\n\014retry_number\030\n" +
       " \001(\005\022\030\n\020method_run_index\030\013 \001(\005\022\023\n\013thread" +
@@ -187,76 +187,76 @@ public final class Framework {
       "odContext.ParametersEntry\022@\n\017custom_cont" +
       "exts\030$ \003(\0132\'.data.MethodContext.CustomCo" +
       "ntextsEntry\0229\n\013annotations\030% \003(\0132$.data." +
-      "MethodContext.AnnotationsEntry\0321\n\017Parame" +
-      "tersEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028" +
-      "\001\0325\n\023CustomContextsEntry\022\013\n\003key\030\001 \001(\t\022\r\n" +
-      "\005value\030\002 \001(\t:\0028\001\0322\n\020AnnotationsEntry\022\013\n\003" +
-      "key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"`\n\rContextV" +
-      "alues\022\n\n\002id\030\001 \001(\t\022\017\n\007created\030\002 \001(\003\022\014\n\004na" +
-      "me\030\003 \001(\t\022\022\n\nstart_time\030\004 \001(\003\022\020\n\010end_time" +
-      "\030\005 \001(\003\"?\n\010TestStep\022\014\n\004name\030\001 \001(\t\022%\n\007acti" +
-      "ons\030\003 \003(\0132\024.data.TestStepAction\"]\n\016TestS" +
-      "tepAction\022\014\n\004name\030\001 \001(\t\022\021\n\ttimestamp\030\003 \001" +
-      "(\003\022*\n\007entries\030\007 \003(\0132\031.data.TestStepActio" +
-      "nEntry\"\273\001\n\023TestStepActionEntry\0220\n\020click_" +
-      "path_event\030\001 \001(\0132\024.data.ClickPathEventH\000" +
-      "\022\027\n\rscreenshot_id\030\002 \001(\tH\000\022\'\n\013log_message" +
-      "\030\003 \001(\0132\020.data.LogMessageH\000\022\'\n\tassertion\030" +
-      "\004 \001(\0132\022.data.ErrorContextH\000B\007\n\005entry\"]\n\016" +
-      "ClickPathEvent\022&\n\004type\030\001 \001(\0162\030.data.Clic" +
-      "kPathEventType\022\017\n\007subject\030\002 \001(\t\022\022\n\nsessi" +
-      "on_id\030\003 \001(\t\"\252\001\n\nLogMessage\022\"\n\004type\030\001 \001(\016" +
-      "2\024.data.LogMessageType\022\023\n\013logger_name\030\002 " +
-      "\001(\t\022\017\n\007message\030\003 \001(\t\022\021\n\ttimestamp\030\004 \001(\003\022" +
-      "\023\n\013thread_name\030\005 \001(\t\022*\n\013stack_trace\030\006 \003(" +
-      "\0132\025.data.StackTraceCause\"\236\001\n\014ErrorContex" +
-      "t\022)\n\rscript_source\030\007 \001(\0132\022.data.ScriptSo" +
-      "urce\022\020\n\010ticketId\030\t \001(\t\022\023\n\013description\030\n " +
-      "\001(\t\022*\n\013stack_trace\030\013 \003(\0132\025.data.StackTra" +
-      "ceCause\022\020\n\010optional\030\014 \001(\010\"\354\001\n\016SessionCon" +
-      "text\022+\n\016context_values\030\001 \001(\0132\023.data.Cont" +
-      "extValues\022\022\n\nsession_id\030\006 \001(\t\022\020\n\010video_i" +
-      "d\030\007 \001(\t\022\034\n\024execution_context_id\030\010 \001(\t\022\024\n" +
-      "\014browser_name\030\t \001(\t\022\027\n\017browser_version\030\n" +
-      " \001(\t\022\024\n\014capabilities\030\013 \001(\t\022\022\n\nserver_url" +
-      "\030\014 \001(\t\022\020\n\010node_url\030\r \001(\t\"c\n\tRunConfig\022\016\n" +
-      "\006runcfg\030\001 \001(\t\0221\n\021build_information\030\002 \001(\013" +
-      "2\026.data.BuildInformation\022\023\n\013report_name\030" +
-      "\003 \001(\t\"\250\001\n\020BuildInformation\022\032\n\022build_java" +
-      "_version\030\001 \001(\t\022\025\n\rbuild_os_name\030\002 \001(\t\022\030\n" +
-      "\020build_os_version\030\003 \001(\t\022\027\n\017build_user_na" +
-      "me\030\004 \001(\t\022\025\n\rbuild_version\030\005 \001(\t\022\027\n\017build" +
-      "_timestamp\030\006 \001(\t\"T\n\017StackTraceCause\022\022\n\nc" +
-      "lass_name\030\001 \001(\t\022\017\n\007message\030\002 \001(\t\022\034\n\024stac" +
-      "k_trace_elements\030\003 \003(\t\"k\n\014ScriptSource\022\021" +
-      "\n\tfile_name\030\001 \001(\t\022\023\n\013method_name\030\002 \001(\t\022%" +
-      "\n\005lines\030\003 \003(\0132\026.data.ScriptSourceLine\022\014\n" +
-      "\004mark\030\004 \001(\005\"5\n\020ScriptSourceLine\022\014\n\004line\030" +
-      "\001 \001(\t\022\023\n\013line_number\030\002 \001(\005\"\253\002\n\004File\022\n\n\002i" +
-      "d\030\001 \001(\t\022\014\n\004size\030\002 \001(\003\022\020\n\010mimetype\030\003 \001(\t\022" +
-      "\025\n\rrelative_path\030\004 \001(\t\022\031\n\021created_timest" +
-      "amp\030\005 \001(\003\022\025\n\rsha1_checksum\030\006 \001(\014\022\"\n\004meta" +
-      "\030\007 \003(\0132\024.data.File.MetaEntry\022\025\n\rlast_mod" +
-      "ified\030\t \001(\003\022\022\n\nproject_id\030\n \001(\t\022\016\n\006job_i" +
-      "d\030\013 \001(\t\022\024\n\014is_directory\030\014 \001(\010\022\014\n\004name\030\r " +
-      "\001(\t\032+\n\tMetaEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002" +
-      " \001(\t:\0028\001*t\n\022ClickPathEventType\022\020\n\014CPET_N" +
-      "OT_SET\020\000\022\017\n\013CPET_WINDOW\020\001\022\016\n\nCPET_CLICK\020" +
-      "\002\022\016\n\nCPET_VALUE\020\003\022\r\n\tCPET_PAGE\020\004\022\014\n\010CPET" +
-      "_URL\020\005*W\n\016LogMessageType\022\013\n\007LMT_OFF\020\000\022\r\n" +
-      "\tLMT_ERROR\020\001\022\014\n\010LMT_WARN\020\002\022\014\n\010LMT_INFO\020\003" +
-      "\022\r\n\tLMT_DEBUG\020\004*O\n\024FailureCorridorValue\022" +
-      "\017\n\013FCV_NOT_SET\020\000\022\014\n\010FCV_HIGH\020\001\022\013\n\007FCV_MI" +
-      "D\020\002\022\013\n\007FCV_LOW\020\003*G\n\nMethodType\022\016\n\nMT_NOT" +
-      "_SET\020\000\022\017\n\013TEST_METHOD\020\001\022\030\n\024CONFIGURATION" +
-      "_METHOD\020\002*\323\001\n\020ResultStatusType\022\017\n\013RST_NO" +
-      "T_SET\020\000\022\n\n\006NO_RUN\020\001\022\010\n\004INFO\020\002\022\013\n\007SKIPPED" +
-      "\020\003\022\n\n\006PASSED\020\004\022\r\n\005MINOR\020\005\032\002\010\001\022\n\n\006FAILED\020" +
-      "\007\022\024\n\014FAILED_MINOR\020\010\032\002\010\001\022\022\n\016FAILED_RETRIE" +
-      "D\020\t\022\023\n\017FAILED_EXPECTED\020\n\022\020\n\014PASSED_RETRY" +
-      "\020\013\022\023\n\013MINOR_RETRY\020\014\032\002\010\001B2\n.eu.tsystems.m" +
-      "ms.tic.testframework.report.modelP\001b\006pro" +
-      "to3"
+      "MethodContext.AnnotationsEntry\022\021\n\ttest_n" +
+      "ame\030& \001(\t\0321\n\017ParametersEntry\022\013\n\003key\030\001 \001(" +
+      "\t\022\r\n\005value\030\002 \001(\t:\0028\001\0325\n\023CustomContextsEn" +
+      "try\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\0322\n\020A" +
+      "nnotationsEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 " +
+      "\001(\t:\0028\001\"`\n\rContextValues\022\n\n\002id\030\001 \001(\t\022\017\n\007" +
+      "created\030\002 \001(\003\022\014\n\004name\030\003 \001(\t\022\022\n\nstart_tim" +
+      "e\030\004 \001(\003\022\020\n\010end_time\030\005 \001(\003\"?\n\010TestStep\022\014\n" +
+      "\004name\030\001 \001(\t\022%\n\007actions\030\003 \003(\0132\024.data.Test" +
+      "StepAction\"]\n\016TestStepAction\022\014\n\004name\030\001 \001" +
+      "(\t\022\021\n\ttimestamp\030\003 \001(\003\022*\n\007entries\030\007 \003(\0132\031" +
+      ".data.TestStepActionEntry\"\273\001\n\023TestStepAc" +
+      "tionEntry\0220\n\020click_path_event\030\001 \001(\0132\024.da" +
+      "ta.ClickPathEventH\000\022\027\n\rscreenshot_id\030\002 \001" +
+      "(\tH\000\022\'\n\013log_message\030\003 \001(\0132\020.data.LogMess" +
+      "ageH\000\022\'\n\tassertion\030\004 \001(\0132\022.data.ErrorCon" +
+      "textH\000B\007\n\005entry\"]\n\016ClickPathEvent\022&\n\004typ" +
+      "e\030\001 \001(\0162\030.data.ClickPathEventType\022\017\n\007sub" +
+      "ject\030\002 \001(\t\022\022\n\nsession_id\030\003 \001(\t\"\252\001\n\nLogMe" +
+      "ssage\022\"\n\004type\030\001 \001(\0162\024.data.LogMessageTyp" +
+      "e\022\023\n\013logger_name\030\002 \001(\t\022\017\n\007message\030\003 \001(\t\022" +
+      "\021\n\ttimestamp\030\004 \001(\003\022\023\n\013thread_name\030\005 \001(\t\022" +
+      "*\n\013stack_trace\030\006 \003(\0132\025.data.StackTraceCa" +
+      "use\"\236\001\n\014ErrorContext\022)\n\rscript_source\030\007 " +
+      "\001(\0132\022.data.ScriptSource\022\020\n\010ticketId\030\t \001(" +
+      "\t\022\023\n\013description\030\n \001(\t\022*\n\013stack_trace\030\013 " +
+      "\003(\0132\025.data.StackTraceCause\022\020\n\010optional\030\014" +
+      " \001(\010\"\354\001\n\016SessionContext\022+\n\016context_value" +
+      "s\030\001 \001(\0132\023.data.ContextValues\022\022\n\nsession_" +
+      "id\030\006 \001(\t\022\020\n\010video_id\030\007 \001(\t\022\034\n\024execution_" +
+      "context_id\030\010 \001(\t\022\024\n\014browser_name\030\t \001(\t\022\027" +
+      "\n\017browser_version\030\n \001(\t\022\024\n\014capabilities\030" +
+      "\013 \001(\t\022\022\n\nserver_url\030\014 \001(\t\022\020\n\010node_url\030\r " +
+      "\001(\t\"c\n\tRunConfig\022\016\n\006runcfg\030\001 \001(\t\0221\n\021buil" +
+      "d_information\030\002 \001(\0132\026.data.BuildInformat" +
+      "ion\022\023\n\013report_name\030\003 \001(\t\"\250\001\n\020BuildInform" +
+      "ation\022\032\n\022build_java_version\030\001 \001(\t\022\025\n\rbui" +
+      "ld_os_name\030\002 \001(\t\022\030\n\020build_os_version\030\003 \001" +
+      "(\t\022\027\n\017build_user_name\030\004 \001(\t\022\025\n\rbuild_ver" +
+      "sion\030\005 \001(\t\022\027\n\017build_timestamp\030\006 \001(\t\"T\n\017S" +
+      "tackTraceCause\022\022\n\nclass_name\030\001 \001(\t\022\017\n\007me" +
+      "ssage\030\002 \001(\t\022\034\n\024stack_trace_elements\030\003 \003(" +
+      "\t\"k\n\014ScriptSource\022\021\n\tfile_name\030\001 \001(\t\022\023\n\013" +
+      "method_name\030\002 \001(\t\022%\n\005lines\030\003 \003(\0132\026.data." +
+      "ScriptSourceLine\022\014\n\004mark\030\004 \001(\005\"5\n\020Script" +
+      "SourceLine\022\014\n\004line\030\001 \001(\t\022\023\n\013line_number\030" +
+      "\002 \001(\005\"\253\002\n\004File\022\n\n\002id\030\001 \001(\t\022\014\n\004size\030\002 \001(\003" +
+      "\022\020\n\010mimetype\030\003 \001(\t\022\025\n\rrelative_path\030\004 \001(" +
+      "\t\022\031\n\021created_timestamp\030\005 \001(\003\022\025\n\rsha1_che" +
+      "cksum\030\006 \001(\014\022\"\n\004meta\030\007 \003(\0132\024.data.File.Me" +
+      "taEntry\022\025\n\rlast_modified\030\t \001(\003\022\022\n\nprojec" +
+      "t_id\030\n \001(\t\022\016\n\006job_id\030\013 \001(\t\022\024\n\014is_directo" +
+      "ry\030\014 \001(\010\022\014\n\004name\030\r \001(\t\032+\n\tMetaEntry\022\013\n\003k" +
+      "ey\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001*t\n\022ClickPath" +
+      "EventType\022\020\n\014CPET_NOT_SET\020\000\022\017\n\013CPET_WIND" +
+      "OW\020\001\022\016\n\nCPET_CLICK\020\002\022\016\n\nCPET_VALUE\020\003\022\r\n\t" +
+      "CPET_PAGE\020\004\022\014\n\010CPET_URL\020\005*W\n\016LogMessageT" +
+      "ype\022\013\n\007LMT_OFF\020\000\022\r\n\tLMT_ERROR\020\001\022\014\n\010LMT_W" +
+      "ARN\020\002\022\014\n\010LMT_INFO\020\003\022\r\n\tLMT_DEBUG\020\004*O\n\024Fa" +
+      "ilureCorridorValue\022\017\n\013FCV_NOT_SET\020\000\022\014\n\010F" +
+      "CV_HIGH\020\001\022\013\n\007FCV_MID\020\002\022\013\n\007FCV_LOW\020\003*G\n\nM" +
+      "ethodType\022\016\n\nMT_NOT_SET\020\000\022\017\n\013TEST_METHOD" +
+      "\020\001\022\030\n\024CONFIGURATION_METHOD\020\002*\323\001\n\020ResultS" +
+      "tatusType\022\017\n\013RST_NOT_SET\020\000\022\n\n\006NO_RUN\020\001\022\010" +
+      "\n\004INFO\020\002\022\013\n\007SKIPPED\020\003\022\n\n\006PASSED\020\004\022\r\n\005MIN" +
+      "OR\020\005\032\002\010\001\022\n\n\006FAILED\020\007\022\024\n\014FAILED_MINOR\020\010\032\002" +
+      "\010\001\022\022\n\016FAILED_RETRIED\020\t\022\023\n\017FAILED_EXPECTE" +
+      "D\020\n\022\020\n\014PASSED_RETRY\020\013\022\023\n\013MINOR_RETRY\020\014\032\002" +
+      "\010\001B2\n.eu.tsystems.mms.tic.testframework." +
+      "report.modelP\001b\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -297,7 +297,7 @@ public final class Framework {
     internal_static_data_MethodContext_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_data_MethodContext_descriptor,
-        new java.lang.String[] { "ContextValues", "MethodType", "RetryNumber", "MethodRunIndex", "ThreadName", "FailureCorridorValue", "ClassContextId", "ExecutionContextId", "Infos", "PriorityMessage", "RelatedMethodContextIds", "DependsOnMethodContextIds", "ErrorContext", "TestSteps", "TestContextId", "SuiteContextId", "SessionContextIds", "FailedStepIndex", "ResultStatus", "Parameters", "CustomContexts", "Annotations", });
+        new java.lang.String[] { "ContextValues", "MethodType", "RetryNumber", "MethodRunIndex", "ThreadName", "FailureCorridorValue", "ClassContextId", "ExecutionContextId", "Infos", "PriorityMessage", "RelatedMethodContextIds", "DependsOnMethodContextIds", "ErrorContext", "TestSteps", "TestContextId", "SuiteContextId", "SessionContextIds", "FailedStepIndex", "ResultStatus", "Parameters", "CustomContexts", "Annotations", "TestName", });
     internal_static_data_MethodContext_ParametersEntry_descriptor =
       internal_static_data_MethodContext_descriptor.getNestedTypes().get(0);
     internal_static_data_MethodContext_ParametersEntry_fieldAccessorTable = new

--- a/report-model/src/main/java/eu/tsystems/mms/tic/testframework/report/model/MethodContext.java
+++ b/report-model/src/main/java/eu/tsystems/mms/tic/testframework/report/model/MethodContext.java
@@ -30,6 +30,7 @@ private static final long serialVersionUID = 0L;
     suiteContextId_ = "";
     sessionContextIds_ = com.google.protobuf.LazyStringArrayList.EMPTY;
     resultStatus_ = 0;
+    testName_ = "";
   }
 
   @java.lang.Override
@@ -240,6 +241,12 @@ private static final long serialVersionUID = 0L;
                 AnnotationsDefaultEntryHolder.defaultEntry.getParserForType(), extensionRegistry);
             annotations_.getMutableMap().put(
                 annotations__.getKey(), annotations__.getValue());
+            break;
+          }
+          case 306: {
+            java.lang.String s = input.readStringRequireUtf8();
+
+            testName_ = s;
             break;
           }
           default: {
@@ -1137,6 +1144,52 @@ private static final long serialVersionUID = 0L;
     return map.get(key);
   }
 
+  public static final int TEST_NAME_FIELD_NUMBER = 38;
+  private volatile java.lang.Object testName_;
+  /**
+   * <pre>
+   * A custom generated test name (e.a. cucumber scenario)
+   * </pre>
+   *
+   * <code>string test_name = 38;</code>
+   * @return The testName.
+   */
+  @java.lang.Override
+  public java.lang.String getTestName() {
+    java.lang.Object ref = testName_;
+    if (ref instanceof java.lang.String) {
+      return (java.lang.String) ref;
+    } else {
+      com.google.protobuf.ByteString bs = 
+          (com.google.protobuf.ByteString) ref;
+      java.lang.String s = bs.toStringUtf8();
+      testName_ = s;
+      return s;
+    }
+  }
+  /**
+   * <pre>
+   * A custom generated test name (e.a. cucumber scenario)
+   * </pre>
+   *
+   * <code>string test_name = 38;</code>
+   * @return The bytes for testName.
+   */
+  @java.lang.Override
+  public com.google.protobuf.ByteString
+      getTestNameBytes() {
+    java.lang.Object ref = testName_;
+    if (ref instanceof java.lang.String) {
+      com.google.protobuf.ByteString b = 
+          com.google.protobuf.ByteString.copyFromUtf8(
+              (java.lang.String) ref);
+      testName_ = b;
+      return b;
+    } else {
+      return (com.google.protobuf.ByteString) ref;
+    }
+  }
+
   private byte memoizedIsInitialized = -1;
   @java.lang.Override
   public final boolean isInitialized() {
@@ -1226,6 +1279,9 @@ private static final long serialVersionUID = 0L;
         internalGetAnnotations(),
         AnnotationsDefaultEntryHolder.defaultEntry,
         37);
+    if (!getTestNameBytes().isEmpty()) {
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 38, testName_);
+    }
     unknownFields.writeTo(output);
   }
 
@@ -1351,6 +1407,9 @@ private static final long serialVersionUID = 0L;
       size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(37, annotations__);
     }
+    if (!getTestNameBytes().isEmpty()) {
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(38, testName_);
+    }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
     return size;
@@ -1413,6 +1472,8 @@ private static final long serialVersionUID = 0L;
         other.internalGetCustomContexts())) return false;
     if (!internalGetAnnotations().equals(
         other.internalGetAnnotations())) return false;
+    if (!getTestName()
+        .equals(other.getTestName())) return false;
     if (!unknownFields.equals(other.unknownFields)) return false;
     return true;
   }
@@ -1488,6 +1549,8 @@ private static final long serialVersionUID = 0L;
       hash = (37 * hash) + ANNOTATIONS_FIELD_NUMBER;
       hash = (53 * hash) + internalGetAnnotations().hashCode();
     }
+    hash = (37 * hash) + TEST_NAME_FIELD_NUMBER;
+    hash = (53 * hash) + getTestName().hashCode();
     hash = (29 * hash) + unknownFields.hashCode();
     memoizedHashCode = hash;
     return hash;
@@ -1705,6 +1768,8 @@ private static final long serialVersionUID = 0L;
       internalGetMutableParameters().clear();
       internalGetMutableCustomContexts().clear();
       internalGetMutableAnnotations().clear();
+      testName_ = "";
+
       return this;
     }
 
@@ -1789,6 +1854,7 @@ private static final long serialVersionUID = 0L;
       result.customContexts_.makeImmutable();
       result.annotations_ = internalGetAnnotations();
       result.annotations_.makeImmutable();
+      result.testName_ = testName_;
       onBuilt();
       return result;
     }
@@ -1957,6 +2023,10 @@ private static final long serialVersionUID = 0L;
           other.internalGetCustomContexts());
       internalGetMutableAnnotations().mergeFrom(
           other.internalGetAnnotations());
+      if (!other.getTestName().isEmpty()) {
+        testName_ = other.testName_;
+        onChanged();
+      }
       this.mergeUnknownFields(other.unknownFields);
       onChanged();
       return this;
@@ -4095,6 +4165,102 @@ private static final long serialVersionUID = 0L;
         java.util.Map<java.lang.String, java.lang.String> values) {
       internalGetMutableAnnotations().getMutableMap()
           .putAll(values);
+      return this;
+    }
+
+    private java.lang.Object testName_ = "";
+    /**
+     * <pre>
+     * A custom generated test name (e.a. cucumber scenario)
+     * </pre>
+     *
+     * <code>string test_name = 38;</code>
+     * @return The testName.
+     */
+    public java.lang.String getTestName() {
+      java.lang.Object ref = testName_;
+      if (!(ref instanceof java.lang.String)) {
+        com.google.protobuf.ByteString bs =
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        testName_ = s;
+        return s;
+      } else {
+        return (java.lang.String) ref;
+      }
+    }
+    /**
+     * <pre>
+     * A custom generated test name (e.a. cucumber scenario)
+     * </pre>
+     *
+     * <code>string test_name = 38;</code>
+     * @return The bytes for testName.
+     */
+    public com.google.protobuf.ByteString
+        getTestNameBytes() {
+      java.lang.Object ref = testName_;
+      if (ref instanceof String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        testName_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+    /**
+     * <pre>
+     * A custom generated test name (e.a. cucumber scenario)
+     * </pre>
+     *
+     * <code>string test_name = 38;</code>
+     * @param value The testName to set.
+     * @return This builder for chaining.
+     */
+    public Builder setTestName(
+        java.lang.String value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  
+      testName_ = value;
+      onChanged();
+      return this;
+    }
+    /**
+     * <pre>
+     * A custom generated test name (e.a. cucumber scenario)
+     * </pre>
+     *
+     * <code>string test_name = 38;</code>
+     * @return This builder for chaining.
+     */
+    public Builder clearTestName() {
+      
+      testName_ = getDefaultInstance().getTestName();
+      onChanged();
+      return this;
+    }
+    /**
+     * <pre>
+     * A custom generated test name (e.a. cucumber scenario)
+     * </pre>
+     *
+     * <code>string test_name = 38;</code>
+     * @param value The bytes for testName to set.
+     * @return This builder for chaining.
+     */
+    public Builder setTestNameBytes(
+        com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+      
+      testName_ = value;
+      onChanged();
       return this;
     }
     @java.lang.Override

--- a/report-model/src/main/java/eu/tsystems/mms/tic/testframework/report/model/MethodContextOrBuilder.java
+++ b/report-model/src/main/java/eu/tsystems/mms/tic/testframework/report/model/MethodContextOrBuilder.java
@@ -424,4 +424,24 @@ public interface MethodContextOrBuilder extends
 
   java.lang.String getAnnotationsOrThrow(
       java.lang.String key);
+
+  /**
+   * <pre>
+   * A custom generated test name (e.a. cucumber scenario)
+   * </pre>
+   *
+   * <code>string test_name = 38;</code>
+   * @return The testName.
+   */
+  java.lang.String getTestName();
+  /**
+   * <pre>
+   * A custom generated test name (e.a. cucumber scenario)
+   * </pre>
+   *
+   * <code>string test_name = 38;</code>
+   * @return The bytes for testName.
+   */
+  com.google.protobuf.ByteString
+      getTestNameBytes();
 }

--- a/report-model/src/main/proto/framework.proto
+++ b/report-model/src/main/proto/framework.proto
@@ -94,6 +94,8 @@ message MethodContext {
     map<string,string> parameters = 35;
     map<string,string> custom_contexts = 36;
     map<string,string> annotations = 37;
+    // A custom generated test name (e.a. cucumber scenario)
+    string test_name = 38;
 }
 
 message ContextValues {

--- a/report-ng/app/src/services/report-model.d.ts
+++ b/report-ng/app/src/services/report-model.d.ts
@@ -310,6 +310,9 @@ export namespace data {
 
         /** MethodContext annotations */
         annotations?: ({ [k: string]: string }|null);
+
+        /** MethodContext testName */
+        testName?: (string|null);
     }
 
     /** Represents a MethodContext. */
@@ -386,6 +389,9 @@ export namespace data {
 
         /** MethodContext annotations. */
         public annotations: { [k: string]: string };
+
+        /** MethodContext testName. */
+        public testName: string;
 
         /**
          * Decodes a MethodContext message from the specified reader or buffer.
@@ -559,7 +565,7 @@ export namespace data {
         public clickPathEvent?: (data.IClickPathEvent|null);
 
         /** TestStepActionEntry screenshotId. */
-        public screenshotId: string;
+        public screenshotId?: (string|null);
 
         /** TestStepActionEntry logMessage. */
         public logMessage?: (data.ILogMessage|null);

--- a/report-ng/app/src/services/report-model.js
+++ b/report-ng/app/src/services/report-model.js
@@ -578,6 +578,7 @@ export const data = $root.data = (() => {
          * @property {Object.<string,string>|null} [parameters] MethodContext parameters
          * @property {Object.<string,string>|null} [customContexts] MethodContext customContexts
          * @property {Object.<string,string>|null} [annotations] MethodContext annotations
+         * @property {string|null} [testName] MethodContext testName
          */
 
         /**
@@ -780,6 +781,14 @@ export const data = $root.data = (() => {
         MethodContext.prototype.annotations = $util.emptyObject;
 
         /**
+         * MethodContext testName.
+         * @member {string} testName
+         * @memberof data.MethodContext
+         * @instance
+         */
+        MethodContext.prototype.testName = "";
+
+        /**
          * Decodes a MethodContext message from the specified reader or buffer.
          * @function decode
          * @memberof data.MethodContext
@@ -929,6 +938,9 @@ export const data = $root.data = (() => {
                         }
                     }
                     m.annotations[k] = value;
+                    break;
+                case 38:
+                    m.testName = r.string();
                     break;
                 default:
                     r.skipType(t & 7);
@@ -1260,11 +1272,11 @@ export const data = $root.data = (() => {
 
         /**
          * TestStepActionEntry screenshotId.
-         * @member {string} screenshotId
+         * @member {string|null|undefined} screenshotId
          * @memberof data.TestStepActionEntry
          * @instance
          */
-        TestStepActionEntry.prototype.screenshotId = "";
+        TestStepActionEntry.prototype.screenshotId = null;
 
         /**
          * TestStepActionEntry logMessage.

--- a/report-ng/app/src/services/statistics-generator.ts
+++ b/report-ng/app/src/services/statistics-generator.ts
@@ -80,12 +80,10 @@ export class MethodDetails {
 
     get identifier() {
         if (!this._identifier) {
-            this._identifier = this.methodContext.contextValues.name;
-            const otherMethodWithSameName = this.classStatistics.methodContexts
-                .find(otherMethodContext => {
-                    return (otherMethodContext.contextValues.id !== this.methodContext.contextValues.id && this.methodContext.contextValues.name === otherMethodContext.contextValues.name)
-                });
-            if (otherMethodWithSameName) {
+            if (this.methodContext.testName) {
+                this._identifier = this.methodContext.testName;
+            } else {
+                this._identifier = this.methodContext.contextValues.name;
                 const params = [];
                 for (const name in this.methodContext.parameters) {
                     params.push(name + ": " + this.methodContext.parameters[name]);


### PR DESCRIPTION
# Description

* This feature brings custom *test names* to the *MethodContext* proto model, which allows to differentiate between method name and test name generated by `cucumber-connector` for example.
![image](https://user-images.githubusercontent.com/572453/121342275-c4ee7e00-c921-11eb-8a6f-ea14aca7bbd4.png)
* Also: All parameters of a test method are now shown.
![image](https://user-images.githubusercontent.com/572453/121342314-cd46b900-c921-11eb-8993-9c9cc7b2bb3f.png)


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
