### PR TITLE
Fix: label for email badge in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ The following channels are available for discussions, feedback, and support requ
 | Type                     | Channel                                                |
 | ------------------------ | ------------------------------------------------------ |
 | **Issues**   | <a href="https://github.com/telekom/testerra/issues/new/choose" title="Issues"><img src="https://img.shields.io/github/issues/telekom/testerra?style=flat"></a> |
-| **Other Requests**    | <a href="mailto:testerra@t-systems-mms.com" title="Email us"><img src="https://img.shields.io/badge/email-CWA%20team-green?logo=mail.ru&style=flat-square&logoColor=white"></a>   |
+| **Other Requests**    | <a href="mailto:testerra@t-systems-mms.com" title="Email us"><img src="https://img.shields.io/badge/email-Testerra%20team-green?logo=mail.ru&style=flat-square&logoColor=white"></a>   |
 
 ## Additional repositories
 


### PR DESCRIPTION
# Description

Fix label for e-mail badge (now correctly refers to the Testerra team) 