### PR TITLE
Improved logging for missing browser configuration. Fixes #79.

### DIFF
--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/WebDriverSessionsManager.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/WebDriverSessionsManager.java
@@ -21,6 +21,7 @@
  */
  package eu.tsystems.mms.tic.testframework.webdrivermanager;
 
+import eu.tsystems.mms.tic.testframework.constants.TesterraProperties;
 import eu.tsystems.mms.tic.testframework.events.ContextUpdateEvent;
 import eu.tsystems.mms.tic.testframework.exceptions.SystemException;
 import eu.tsystems.mms.tic.testframework.internal.Flags;
@@ -325,6 +326,11 @@ public final class WebDriverSessionsManager {
         }
 
         String browser = webDriverRequest.getBrowser();
+
+        if (StringUtils.isBlank(browser)) {
+            throw new SystemException(String.format("No browser configured. Please define one in %s.setBrowser() or property '%s'", WebDriverRequest.class.getSimpleName(), TesterraProperties.BROWSER));
+        }
+
         String sessionKey = webDriverRequest.getSessionKey();
         /*
         Check for exclusive session
@@ -386,7 +392,7 @@ public final class WebDriverSessionsManager {
             });
             return newWebDriver;
         } else {
-            throw new SystemException("No webdriver factory registered for browser " + browser);
+            throw new SystemException(String.format("No %s registered for browser '%s'", WebDriverFactory.class.getSimpleName(), browser));
         }
     }
 


### PR DESCRIPTION
# Description

Added exception message for missing browser configuration.

```
No WebDriverFactory registered for browser 'adsasasd'
```

```
No browser configured. Please define one in WebDriverRequest.setBrowser() or property 'tt.browser'
```

Fixes #79

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
