### PR TITLE
Fixed cutting element image from full screenshot.

### DIFF
--- a/driver-ui-desktop/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/internal/core/DesktopGuiElementCore.java
+++ b/driver-ui-desktop/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/internal/core/DesktopGuiElementCore.java
@@ -684,22 +684,25 @@ public class DesktopGuiElementCore implements GuiElementCore, Loggable {
 
                 Point elementPosition = webElement.getLocation();
                 Dimension elementSize = webElement.getSize();
+                int imageX = elementPosition.getX() - viewport.getX();
+                int imageY = elementPosition.getY() - viewport.getY();
                 int imageWidth = elementSize.getWidth();
                 int imageHeight = elementSize.getHeight();
 
-                Point imagePosition = new Point(elementPosition.getX() - viewport.getX(), elementPosition.getY() - viewport.getY());
+                if (imageX > fullImg.getWidth()) imageX = 0;
+                if (imageY > fullImg.getHeight()) imageY = 0;
 
                 // Make sure the image bounding box doesn't overflows the image dimension
-                if (imagePosition.getX() + imageWidth > fullImg.getWidth()) {
-                    imageWidth = fullImg.getWidth() - imagePosition.getX();
+                if (imageX + imageWidth > fullImg.getWidth()) {
+                    imageWidth = fullImg.getWidth() - imageX;
                 }
-                if (imagePosition.getY() + imageHeight > fullImg.getHeight()) {
-                    imageHeight = fullImg.getHeight() - imagePosition.getY();
+                if (imageY + imageHeight > fullImg.getHeight()) {
+                    imageHeight = fullImg.getHeight() - imageY;
                 }
 
                 BufferedImage eleScreenshot = fullImg.getSubimage(
-                        imagePosition.getX(),
-                        imagePosition.getY(),
+                        imageX,
+                        imageY,
                         imageWidth,
                         imageHeight
                 );

--- a/driver-ui-desktop/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/internal/core/DesktopGuiElementCore.java
+++ b/driver-ui-desktop/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/internal/core/DesktopGuiElementCore.java
@@ -666,11 +666,11 @@ public class DesktopGuiElementCore implements GuiElementCore, Loggable {
 
     @Override
     public File takeScreenshot() {
-        final WebElement element = getWebElement();
+        final WebElement webElement = getWebElement();
         final boolean isSelenium4 = false;
 
         if (isSelenium4) {
-            return element.getScreenshotAs(OutputType.FILE);
+            return webElement.getScreenshotAs(OutputType.FILE);
         } else {
             if (!isVisible(false)) {
                 scrollIntoView();
@@ -682,15 +682,26 @@ public class DesktopGuiElementCore implements GuiElementCore, Loggable {
                 File screenshot = driver.getScreenshotAs(OutputType.FILE);
                 BufferedImage fullImg = ImageIO.read(screenshot);
 
-                Point point = element.getLocation();
-                int eleWidth = element.getSize().getWidth();
-                int eleHeight = element.getSize().getHeight();
+                Point elementPosition = webElement.getLocation();
+                Dimension elementSize = webElement.getSize();
+                int imageWidth = elementSize.getWidth();
+                int imageHeight = elementSize.getHeight();
+
+                Point imagePosition = new Point(elementPosition.getX() - viewport.getX(), elementPosition.getY() - viewport.getY());
+
+                // Make sure the image bounding box doesn't overflows the image dimension
+                if (imagePosition.getX() + imageWidth > fullImg.getWidth()) {
+                    imageWidth = fullImg.getWidth() - imagePosition.getX();
+                }
+                if (imagePosition.getY() + imageHeight > fullImg.getHeight()) {
+                    imageHeight = fullImg.getHeight() - imagePosition.getY();
+                }
 
                 BufferedImage eleScreenshot = fullImg.getSubimage(
-                        point.getX() - viewport.getX(),
-                        point.getY() - viewport.getY(),
-                        eleWidth,
-                        eleHeight
+                        imagePosition.getX(),
+                        imagePosition.getY(),
+                        imageWidth,
+                        imageHeight
                 );
                 ImageIO.write(eleScreenshot, "png", screenshot);
                 return screenshot;

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/utils/WebDriverUtils.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/utils/WebDriverUtils.java
@@ -303,7 +303,7 @@ public final class WebDriverUtils {
     public static Rectangle getViewport(WebDriver driver) {
 
         final ArrayList<String> list = (ArrayList<String>) JSUtils.executeScript(driver, "return [window.pageXOffset.toString(), window.pageYOffset.toString(), window.innerWidth.toString(), window.innerHeight.toString()];");
-        return new Rectangle(Integer.valueOf(list.get(0)), Integer.valueOf(list.get(1)), Integer.valueOf(list.get(2)), Integer.valueOf(list.get(3)));
+        return new Rectangle(Integer.valueOf(list.get(0)), Integer.valueOf(list.get(1)), Integer.valueOf(list.get(3)), Integer.valueOf(list.get(2)));
     }
 
 


### PR DESCRIPTION
# Description

This is a backport from Testerra 2 element screenshot. It fixes cropping the image, when the element dimensions are bigger than the screenshot dimensions.

- Fixes #86 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
