### PR TITLE
Fix for empty test step action entries when there is actually no screenshot id present

### DIFF
--- a/report-model/src/main/java/eu/tsystems/mms/tic/testframework/adapters/ContextExporter.java
+++ b/report-model/src/main/java/eu/tsystems/mms/tic/testframework/adapters/ContextExporter.java
@@ -69,6 +69,7 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Level;
 
 public class ContextExporter implements Loggable {
@@ -332,7 +333,7 @@ public class ContextExporter implements Loggable {
                     entryBuilder.hasAssertion()
                     || entryBuilder.hasLogMessage()
                     || entryBuilder.hasClickPathEvent()
-                    || entryBuilder.getScreenshotId() != null
+                    || StringUtils.isNotBlank(entryBuilder.getScreenshotId())
             ) {
                 actionBuilder.addEntries(entryBuilder);
             }


### PR DESCRIPTION
# Description

Prevents creating empty `TestStepActionEntry` items in test steps.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
