### PR TITLE
Capabilites of DesktopWebDriverRequest not clonable

### DIFF
--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/report/model/context/SessionContext.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/report/model/context/SessionContext.java
@@ -43,7 +43,11 @@ public class SessionContext extends AbstractContext implements SynchronizableCon
     private final Queue<MethodContext> methodContexts = new ConcurrentLinkedQueue<>();
 
     public SessionContext(WebDriverRequest webDriverRequest) {
-        this.webDriverRequest = webDriverRequest.clone();
+        try {
+            this.webDriverRequest = webDriverRequest.clone();
+        } catch (CloneNotSupportedException e) {
+            throw new RuntimeException(e);
+        }
         this.name = webDriverRequest.getSessionKey();
 
 //        this.provider = provider;

--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/report/model/context/SessionContext.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/report/model/context/SessionContext.java
@@ -43,7 +43,7 @@ public class SessionContext extends AbstractContext implements SynchronizableCon
     private final Queue<MethodContext> methodContexts = new ConcurrentLinkedQueue<>();
 
     public SessionContext(WebDriverRequest webDriverRequest) {
-        this.webDriverRequest = SerializationUtils.clone(webDriverRequest);
+        this.webDriverRequest = webDriverRequest.clone();
         this.name = webDriverRequest.getSessionKey();
 
 //        this.provider = provider;

--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/WebDriverRequest.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/WebDriverRequest.java
@@ -1,13 +1,12 @@
 package eu.tsystems.mms.tic.testframework.webdrivermanager;
 
-import java.io.Serializable;
 import java.net.URL;
 import java.util.Optional;
 
-public interface WebDriverRequest extends Serializable {
+public interface WebDriverRequest extends Cloneable {
     String getSessionKey();
     String getBrowser();
     String getBrowserVersion();
     Optional<URL> getServerUrl();
-    WebDriverRequest clone();
+    WebDriverRequest clone() throws CloneNotSupportedException;
 }

--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/WebDriverRequest.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/WebDriverRequest.java
@@ -9,4 +9,5 @@ public interface WebDriverRequest extends Serializable {
     String getBrowser();
     String getBrowserVersion();
     Optional<URL> getServerUrl();
+    WebDriverRequest clone();
 }

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/AbstractWebDriverRequest.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/AbstractWebDriverRequest.java
@@ -20,12 +20,9 @@
  */
 package eu.tsystems.mms.tic.testframework.webdrivermanager;
 
-import org.apache.commons.lang3.SerializationUtils;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
-import java.io.Serializable;
-
-public abstract class AbstractWebDriverRequest extends AbstractWebDriverConfiguration implements Serializable, WebDriverRequest {
+public abstract class AbstractWebDriverRequest extends AbstractWebDriverConfiguration implements WebDriverRequest {
     private String sessionKey;
     private DesiredCapabilities desiredCapabilities;
 
@@ -52,19 +49,12 @@ public abstract class AbstractWebDriverRequest extends AbstractWebDriverConfigur
      *
      * @return
      */
-    public AbstractWebDriverRequest clone() {
-        Class<? extends AbstractWebDriverRequest> clazz = this.getClass();
-        DesiredCapabilities cloneCaps = new DesiredCapabilities();
-
-        // Backup original caps and set this caps to NULL to be cloneable
-        cloneCaps.merge(this.getDesiredCapabilities());
-        this.desiredCapabilities = null;
-        AbstractWebDriverRequest clone = SerializationUtils.clone(this);
-
-        // Write back original caps to this and to clone object.
-        clone.getDesiredCapabilities().merge(cloneCaps);
-        this.desiredCapabilities = cloneCaps;
-        
-        return clazz.cast(clone);
+    public AbstractWebDriverRequest clone() throws CloneNotSupportedException {
+        AbstractWebDriverRequest clone = (AbstractWebDriverRequest) super.clone();
+        if (this.desiredCapabilities != null) {
+            clone.desiredCapabilities = new DesiredCapabilities();
+            clone.desiredCapabilities.merge(this.desiredCapabilities);
+        }
+        return clone;
     }
 }

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/AbstractWebDriverRequest.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/AbstractWebDriverRequest.java
@@ -64,20 +64,7 @@ public abstract class AbstractWebDriverRequest extends AbstractWebDriverConfigur
         // Write back original caps to this and to clone object.
         clone.getDesiredCapabilities().merge(cloneCaps);
         this.desiredCapabilities = cloneCaps;
-
-//        boolean isCaps = this.desiredCapabilities != null;
-//        // Backup original caps
-//        if (isCaps) {
-//            cloneCaps = new DesiredCapabilities();
-//            cloneCaps.merge(this.desiredCapabilities);
-//            this.desiredCapabilities = null;
-//        }
-//        AbstractWebDriverRequest clone = SerializationUtils.clone(this);
-//        // Write back original caps to this and to clone object.
-//        if (isCaps) {
-//            clone.getDesiredCapabilities().merge(cloneCaps);
-//            this.desiredCapabilities = cloneCaps;
-//        }
+        
         return clazz.cast(clone);
     }
 }

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/AbstractWebDriverRequest.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/AbstractWebDriverRequest.java
@@ -53,21 +53,31 @@ public abstract class AbstractWebDriverRequest extends AbstractWebDriverConfigur
      * @return
      */
     public AbstractWebDriverRequest clone() {
-        Class<? extends AbstractWebDriverRequest> aClass = this.getClass();
+        Class<? extends AbstractWebDriverRequest> clazz = this.getClass();
         DesiredCapabilities cloneCaps = new DesiredCapabilities();
-        boolean isCaps = this.desiredCapabilities != null;
-        // Backup original caps
-        if (isCaps) {
-            cloneCaps = new DesiredCapabilities();
-            cloneCaps.merge(this.desiredCapabilities);
-            this.desiredCapabilities = null;
-        }
+
+        // Backup original caps and set this caps to NULL to be cloneable
+        cloneCaps.merge(this.getDesiredCapabilities());
+        this.desiredCapabilities = null;
         AbstractWebDriverRequest clone = SerializationUtils.clone(this);
+
         // Write back original caps to this and to clone object.
-        if (isCaps) {
-            clone.getDesiredCapabilities().merge(cloneCaps);
-            this.desiredCapabilities = cloneCaps;
-        }
-        return aClass.cast(clone);
+        clone.getDesiredCapabilities().merge(cloneCaps);
+        this.desiredCapabilities = cloneCaps;
+
+//        boolean isCaps = this.desiredCapabilities != null;
+//        // Backup original caps
+//        if (isCaps) {
+//            cloneCaps = new DesiredCapabilities();
+//            cloneCaps.merge(this.desiredCapabilities);
+//            this.desiredCapabilities = null;
+//        }
+//        AbstractWebDriverRequest clone = SerializationUtils.clone(this);
+//        // Write back original caps to this and to clone object.
+//        if (isCaps) {
+//            clone.getDesiredCapabilities().merge(cloneCaps);
+//            this.desiredCapabilities = cloneCaps;
+//        }
+        return clazz.cast(clone);
     }
 }

--- a/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/webdrivermanager/WebDriverManagerTest.java
+++ b/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/webdrivermanager/WebDriverManagerTest.java
@@ -154,8 +154,12 @@ public class WebDriverManagerTest extends AbstractWebDriverTest {
         SessionContext sessionContext = WebDriverSessionsManager.getSessionContext(webDriver).get();
         DesktopWebDriverRequest clonedRequest = (DesktopWebDriverRequest) sessionContext.getWebDriverRequest();
 
+        // Test for cloned primitives
         Assert.assertEquals(sessionKey, clonedRequest.getSessionKey());
+        clonedRequest.setSessionKey("NewSessionKey");
+        Assert.assertNotEquals(sessionKey, clonedRequest.getSessionKey());
 
+        // Test for not shallow copy of capabilities
         DesiredCapabilities clonedCaps = clonedRequest.getDesiredCapabilities();
         Assert.assertEquals(capVal, clonedCaps.getCapability(capKey));
         Assert.assertEquals(clonedCaps.getCapability(capKey), baseCaps.getCapability(capKey));

--- a/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/webdrivermanager/WebDriverManagerTest.java
+++ b/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/webdrivermanager/WebDriverManagerTest.java
@@ -25,6 +25,7 @@ import eu.tsystems.mms.tic.testframework.AbstractWebDriverTest;
 import eu.tsystems.mms.tic.testframework.common.PropertyManager;
 import eu.tsystems.mms.tic.testframework.constants.Browsers;
 import eu.tsystems.mms.tic.testframework.constants.TesterraProperties;
+import eu.tsystems.mms.tic.testframework.report.model.context.SessionContext;
 import eu.tsystems.mms.tic.testframework.report.utils.ExecutionContextController;
 import eu.tsystems.mms.tic.testframework.webdrivermanager.DesktopWebDriverRequest;
 import eu.tsystems.mms.tic.testframework.webdrivermanager.WebDriverManager;
@@ -139,15 +140,27 @@ public class WebDriverManagerTest extends AbstractWebDriverTest {
     }
 
     @Test
-    public void testT06_WithDesktopWebDriverRequest() {
+    public void testT06_clonedWebDriverRequest() {
+        final String sessionKey = "testT06";
+        final String capKey = "MyCap";
+        final String capVal = "myValue";
+
         DesktopWebDriverRequest request = new DesktopWebDriverRequest();
-        request.setSessionKey("testT06");
-        DesiredCapabilities caps = request.getDesiredCapabilities();
-        caps.setCapability("MyCap", "myValue");
+        request.setSessionKey(sessionKey);
+        DesiredCapabilities baseCaps = request.getDesiredCapabilities();
+        baseCaps.setCapability(capKey, capVal);
 
         WebDriver webDriver = WebDriverManager.getWebDriver(request);
-        Map<String, Object> capabilities = ExecutionContextController.getCurrentSessionContext().getCapabilities().get();
-        Assert.assertTrue(capabilities.containsKey("MyCap"));
-        Assert.assertEquals(capabilities.get("MyCap"), "myValue");
+        SessionContext sessionContext = WebDriverSessionsManager.getSessionContext(webDriver).get();
+        DesktopWebDriverRequest clonedRequest = (DesktopWebDriverRequest) sessionContext.getWebDriverRequest();
+
+        Assert.assertEquals(sessionKey, clonedRequest.getSessionKey());
+
+        DesiredCapabilities clonedCaps = clonedRequest.getDesiredCapabilities();
+        Assert.assertEquals(capVal, clonedCaps.getCapability(capKey));
+        Assert.assertEquals(clonedCaps.getCapability(capKey), baseCaps.getCapability(capKey));
+
+        clonedCaps.setCapability(capKey, "newValue");
+        Assert.assertNotEquals(clonedCaps.getCapability(capKey), baseCaps.getCapability(capKey));
     }
 }

--- a/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/webdrivermanager/WebDriverManagerTest.java
+++ b/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/webdrivermanager/WebDriverManagerTest.java
@@ -25,14 +25,19 @@ import eu.tsystems.mms.tic.testframework.AbstractWebDriverTest;
 import eu.tsystems.mms.tic.testframework.common.PropertyManager;
 import eu.tsystems.mms.tic.testframework.constants.Browsers;
 import eu.tsystems.mms.tic.testframework.constants.TesterraProperties;
+import eu.tsystems.mms.tic.testframework.report.utils.ExecutionContextController;
+import eu.tsystems.mms.tic.testframework.webdrivermanager.DesktopWebDriverRequest;
 import eu.tsystems.mms.tic.testframework.webdrivermanager.WebDriverManager;
 import eu.tsystems.mms.tic.testframework.webdrivermanager.WebDriverSessionsManager;
-import java.util.Map;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.remote.DesiredCapabilities;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.Optional;
 
 /**
  * Tests for WebDriverManager
@@ -133,4 +138,15 @@ public class WebDriverManagerTest extends AbstractWebDriverTest {
         WebDriverManager.getThreadCapabilities().clear();
     }
 
+    @Test
+    public void testT06_WithDesktopWebDriverRequest() {
+        DesktopWebDriverRequest request = new DesktopWebDriverRequest();
+        request.setSessionKey("testT06");
+        DesiredCapabilities caps = request.getDesiredCapabilities();
+        caps.setCapability("MyCap", "myValue");
+
+        WebDriver webDriver = WebDriverManager.getWebDriver(request);
+        Optional<Map<String, Object>> capabilities = ExecutionContextController.getCurrentSessionContext().getCapabilities();
+
+    }
 }

--- a/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/webdrivermanager/WebDriverManagerTest.java
+++ b/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/webdrivermanager/WebDriverManagerTest.java
@@ -146,7 +146,8 @@ public class WebDriverManagerTest extends AbstractWebDriverTest {
         caps.setCapability("MyCap", "myValue");
 
         WebDriver webDriver = WebDriverManager.getWebDriver(request);
-        Optional<Map<String, Object>> capabilities = ExecutionContextController.getCurrentSessionContext().getCapabilities();
-
+        Map<String, Object> capabilities = ExecutionContextController.getCurrentSessionContext().getCapabilities().get();
+        Assert.assertTrue(capabilities.containsKey("MyCap"));
+        Assert.assertEquals(capabilities.get("MyCap"), "myValue");
     }
 }


### PR DESCRIPTION
# Description

The SessionContext clones the complete WebDriverRequest object after instantiation. In case of existing capabilities the following exception occues because the Capabililies object is not clonable.

`org.apache.commons.lang3.SerializationException: IOException while reading or closing cloned object data`

I've added a special handling of cloning capabilites in `AbstractWebDriverRequest`

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
