### PR TITLE
Fixed crashed test when baseUrl could not be opened.

### DIFF
--- a/driver-ui-desktop/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/DesktopWebDriverFactory.java
+++ b/driver-ui-desktop/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/DesktopWebDriverFactory.java
@@ -43,7 +43,6 @@ import eu.tsystems.mms.tic.testframework.sikuli.SikuliWebDriver;
 import eu.tsystems.mms.tic.testframework.transfer.ThrowablePackedResponse;
 import eu.tsystems.mms.tic.testframework.useragents.UserAgentConfig;
 import eu.tsystems.mms.tic.testframework.utils.FileUtils;
-import eu.tsystems.mms.tic.testframework.utils.StringUtils;
 import eu.tsystems.mms.tic.testframework.utils.Timer;
 import eu.tsystems.mms.tic.testframework.utils.TimerUtils;
 import eu.tsystems.mms.tic.testframework.webdrivermanager.desktop.WebDriverMode;
@@ -127,10 +126,7 @@ public class DesktopWebDriverFactory extends WebDriverFactory<DesktopWebDriverRe
                 StopWatch.startPageLoad(driver);
                 driver.get(baseUrl.toString());
             } catch (Exception e) {
-                if (StringUtils.containsAll(e.getMessage(), true, "Reached error page", "connectionFailure")) {
-                    throw new RuntimeException("Could not start driver session, because of unreachable url: " + baseUrl, e);
-                }
-                throw e;
+                log().error("Unable to open baseUrl", e);
             }
         });
         return driver;


### PR DESCRIPTION
# Description

Dont throw `Exception` when the base URL could not be opened for some reason.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
