### PR TITLE
Removed FTP proxy settings from default proxy

### DIFF
--- a/core-interop/src/main/java/eu/tsystems/mms/tic/testframework/utils/ProxyUtils.java
+++ b/core-interop/src/main/java/eu/tsystems/mms/tic/testframework/utils/ProxyUtils.java
@@ -19,12 +19,13 @@
  * under the License.
  *
  */
- package eu.tsystems.mms.tic.testframework.utils;
+package eu.tsystems.mms.tic.testframework.utils;
 
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLEncoder;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,6 +36,7 @@ public class ProxyUtils {
     /**
      * Will return proxy url like http://{http.proxyUser}:{http.proxyPassword}@{http.proxyHost}:{http.proxyPort}
      * based on the System's proxy settings ea. from the proxysettings.properties file
+     *
      * @return null If there is no URL configured
      */
     public static URL getSystemHttpProxyUrl() {
@@ -44,6 +46,7 @@ public class ProxyUtils {
     /**
      * Will return proxy url like http://{https.proxyUser}:{https.proxyPassword}@{https.proxyHost}:{https.proxyPort}
      * based on the System's proxy settings ea. from the proxysettings.properties file
+     *
      * @return null If there is no URL configured
      */
     public static URL getSystemHttpsProxyUrl() {
@@ -73,7 +76,7 @@ public class ProxyUtils {
      * ProxyType can be "http" or "https" according to java env properties proxy.httpHost or proxy.httpsHost
      *
      * @param proxyType {@link String} http or https
-     * @param prefix    {@link String} Prefix for URL Scheme
+     * @param prefix {@link String} Prefix for URL Scheme
      * @return URL
      */
     private static URL getSpecificProxyTypeUrlWithPrefix(final String proxyType, final String prefix) {
@@ -84,16 +87,16 @@ public class ProxyUtils {
         try {
 
             final String user = System.getProperty(proxyType + ".proxyUser");
-            if (StringUtils.isNotBlank(user)) {
+            if (org.apache.commons.lang3.StringUtils.isNotEmpty(user)) {
                 proxyUrlString += URLEncoder.encode(user, urlEncoding);
             }
 
             final String password = System.getProperty(proxyType + ".proxyPassword");
-            if (StringUtils.isNotBlank(password)) {
+            if (org.apache.commons.lang3.StringUtils.isNotEmpty(password)) {
                 proxyUrlString += ":" + URLEncoder.encode(password, urlEncoding);
             }
 
-            if (StringUtils.isNotBlank(user)) {
+            if (org.apache.commons.lang3.StringUtils.isNotEmpty(user)) {
                 proxyUrlString += "@";
             }
 

--- a/docs/src/docs/browsercaps/proxy-setup.adoc
+++ b/docs/src/docs/browsercaps/proxy-setup.adoc
@@ -45,3 +45,5 @@ public abstract class AbstractTest extends TesterraTest {
     }
 }
 ----
+
+NOTE: `WebDriverProxyUtils.getDefaultHttpProxy()` only returns the proxy configuration for HTTP, HTTPS and non-proxy connections.

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/WebDriverProxyUtils.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/WebDriverProxyUtils.java
@@ -27,7 +27,9 @@ import eu.tsystems.mms.tic.testframework.report.model.context.SessionContext;
 import eu.tsystems.mms.tic.testframework.report.utils.ExecutionContextController;
 import eu.tsystems.mms.tic.testframework.utils.ProxyUtils;
 import eu.tsystems.mms.tic.testframework.utils.StringUtils;
+
 import java.net.URL;
+
 import org.openqa.selenium.Proxy;
 
 public class WebDriverProxyUtils {
@@ -96,7 +98,6 @@ public class WebDriverProxyUtils {
         String proxyString = toProxyString(url);
         Proxy proxy = new Proxy();
         proxy.setHttpProxy(proxyString);
-        proxy.setFtpProxy(proxyString);
         proxy.setSslProxy(proxyString);
         return proxy;
     }
@@ -115,7 +116,9 @@ public class WebDriverProxyUtils {
      */
     public Proxy getDefaultHttpProxy() {
         URL systemProxyUrl = ProxyUtils.getSystemHttpsProxyUrl();
-        if (systemProxyUrl == null) systemProxyUrl = ProxyUtils.getSystemHttpProxyUrl();
+        if (systemProxyUrl == null) {
+            systemProxyUrl = ProxyUtils.getSystemHttpProxyUrl();
+        }
         Proxy proxy = createHttpProxyFromUrl(systemProxyUrl);
         proxy.setNoProxy(PropertyManager.getProperty("https.nonProxyHosts"));
         return proxy;

--- a/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/utils/ProxyUtilsTest.java
+++ b/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/utils/ProxyUtilsTest.java
@@ -19,18 +19,19 @@
  * under the License.
  *
  */
- package eu.tsystems.mms.tic.testframework.test.utils;
+package eu.tsystems.mms.tic.testframework.test.utils;
 
 import eu.tsystems.mms.tic.testframework.testing.TesterraTest;
 import eu.tsystems.mms.tic.testframework.utils.ProxyUtils;
 import eu.tsystems.mms.tic.testframework.webdrivermanager.WebDriverProxyUtils;
-import java.net.MalformedURLException;
-import java.net.URL;
 import org.openqa.selenium.Proxy;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+
+import java.net.MalformedURLException;
+import java.net.URL;
 
 /**
  * Tests class for {@link ProxyUtils} and {@link WebDriverProxyUtils}
@@ -131,8 +132,19 @@ public class ProxyUtilsTest extends TesterraTest {
         WebDriverProxyUtils utils = new WebDriverProxyUtils();
         String proxyString = "http://proxyUser:secretPassword@my-proxy:3128";
         Proxy proxy = utils.createSocksProxyFromUrl(new URL(proxyString));
-        Assert.assertEquals(proxy.getHttpProxy(),"my-proxy:3128");
-        Assert.assertEquals(proxy.getSocksUsername(),"proxyUser");
+        Assert.assertEquals(proxy.getHttpProxy(), "my-proxy:3128");
+        Assert.assertEquals(proxy.getSocksUsername(), "proxyUser");
         Assert.assertEquals(proxy.getSocksPassword(), "secretPassword");
+    }
+
+    @Test
+    public void test06_createDefaultProxyFromUrl() {
+        WebDriverProxyUtils utils = new WebDriverProxyUtils();
+        Proxy proxy = utils.getDefaultHttpProxy();
+
+        Assert.assertEquals(proxy.getHttpProxy(), PROXY_HOST_HTTPS + ":" + PROXY_PORT_HTTPS);
+        Assert.assertEquals(proxy.getSslProxy(), PROXY_HOST_HTTPS + ":" + PROXY_PORT_HTTPS);
+        Assert.assertNull(proxy.getFtpProxy());
+        Assert.assertNull(proxy.getSocksProxy());
     }
 }


### PR DESCRIPTION
# Description

Since Firefox 90 the FTP proxy settings are no longer supported: https://blog.mozilla.org/addons/2021/04/15/built-in-ftp-implementation-to-be-removed-in-firefox-90/.

There is also a note from Selenoid developers: https://github.com/aerokube/selenoid-container-tests/issues/11

Therefor `WebDriverProxyUtils` shouldn't set it per default, but only proxy for HTTP or HTTPS.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
