### PR TITLE
Marked some orphaned annotations as @deprecated

### DIFF
--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/annotations/InDevelopment.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/annotations/InDevelopment.java
@@ -33,6 +33,7 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
+@Deprecated
 public @interface InDevelopment {
 
     String color() default "#a7a5a5";

--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/annotations/InfoMethod.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/annotations/InfoMethod.java
@@ -28,5 +28,6 @@ import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
+@Deprecated
 public @interface InfoMethod {
 }

--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/annotations/New.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/annotations/New.java
@@ -33,6 +33,7 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
+@Deprecated
 public @interface New {
 
     String color() default "cadetblue";

--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/annotations/ReadyForApproval.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/annotations/ReadyForApproval.java
@@ -33,6 +33,7 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
+@Deprecated
 public @interface ReadyForApproval {
 
     String color() default "indianred";

--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/annotations/SupportMethod.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/annotations/SupportMethod.java
@@ -28,6 +28,7 @@ import java.lang.annotation.RetentionPolicy;
  * Flags a method (mainly a @test method) as a support method. Retests wont skip these if previously passed.
  */
 @Retention(RetentionPolicy.RUNTIME)
+@Deprecated
 public @interface SupportMethod {
 
     String color() default "#848282";

--- a/docs/src/docs/execution/execution-annotation.adoc
+++ b/docs/src/docs/execution/execution-annotation.adoc
@@ -4,7 +4,7 @@ include::../properties/property-attributes.adoc[]
 To improve the readability and clarity of the report there are several annotations for marking the test class and test methods,
 which are described in the following paragraphs as well as in <<#Fails, @Fails>>, <<#Retry, @Retry>>, <<#InDevelopment, @InDevelopment>> and <<#NoRetry, @NoRetry>>.
 
-== @New
+== @New (`@deprecated`)
 This marks a test method as `New`, which is shown with this text in the report. Customization is possible with two attributes name and color in the annotation.
 
 * name: change the shown text in the report. Default is `New`
@@ -15,7 +15,7 @@ This marks a test method as `New`, which is shown with this text in the report. 
 ** HSL values, e.g. hsl(217, 97%, 57%)
 ** Hex values, e.g. #57c0ff
 
-== @ReadyForApproval
+== @ReadyForApproval (`@deprecated`)
 This marks a test method as `Ready For Approval`, which is characteristically shown with this text the report. Customization is possible with the two attributes name and color in the annotation.
 
 * name: change the shown text in the report. Default is `Ready For Approval`
@@ -23,16 +23,13 @@ This marks a test method as `Ready For Approval`, which is characteristically sh
 
 See <<New, @New>> for explanation.
 
-== @SupportMethod
+== @SupportMethod (`@deprecated`)
 This marks a test method as `Support Method`, which is characteristically shown with this text the report. Retests won't skip these methods if previously passed. Customization is possible with the two attributes name and color in the annotation.
 
 * name: change the shown text in the report. Default is `Support Method`
 * color: change the background color of the shown text. Default is `#848282`. Values need to be valid for html colors.
 
 See <<New, @New>> for explanation.
-
-== @InfoMethod
-Methods marked with this annotation are shown in the section `Info` of the report.
 
 == @TestClassContext
 With this annotation you can set the test context for the given test class. There two attributes for adjustments.
@@ -43,7 +40,7 @@ With this annotation you can set the test context for the given test class. Ther
 The Executed tests are then shown in the classes overview of the report as a entry labeled with `name` from `@TestClassContext`.
 
 [#InDevelopment]
-== @InDevelopment
+== @InDevelopment (`@deprecated`)
 This aforementioned annotations is further adjustable with the two attributes name and color.
 
 * name: change the shown text in the report. Default is `In Development`


### PR DESCRIPTION
# Description

Marks some annotations as `@deprecated`

## Type of change

- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
