### PR TITLE
Interfaced AnnotationConverter report methods

### DIFF
--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/report/Report.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/report/Report.java
@@ -24,6 +24,8 @@ package eu.tsystems.mms.tic.testframework.report;
 import eu.tsystems.mms.tic.testframework.report.model.context.Screenshot;
 import eu.tsystems.mms.tic.testframework.report.model.context.Video;
 import java.io.File;
+import java.lang.annotation.Annotation;
+import java.util.Optional;
 
 public interface Report {
     String SCREENSHOTS_FOLDER_NAME = "screenshots";
@@ -72,4 +74,24 @@ public interface Report {
      * Returns the relative path of a given report file.
      */
     String getRelativePath(File file);
+
+    /**
+     * Registers a converter for a specific annotation class
+     * @param annotationClass
+     * @param annotationExporter
+     */
+    void registerAnnotationConverter(Class<? extends Annotation> annotationClass, AnnotationConverter annotationExporter);
+
+    /**
+     * Unregisters a converter
+     * @param annotationClass
+     */
+    void unregisterAnnotationConverter(Class<? extends Annotation> annotationClass);
+
+    /**
+     * Gets a converter for a specific annotation class
+     * @param annotation
+     * @return
+     */
+    Optional<AnnotationConverter> getAnnotationConverter(Annotation annotation);
 }

--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/report/TesterraListener.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/report/TesterraListener.java
@@ -110,7 +110,7 @@ public class TesterraListener implements
     private static final Object LOCK = new Object();
     private static final LoggerContext loggerContext;
     private static final BuildInformation buildInformation;
-    private static final DefaultReport report;
+    private static final Report report;
     private static DefaultTestNGContextGenerator contextGenerator;
 
     static {

--- a/report-model/src/main/java/eu/tsystems/mms/tic/testframework/adapters/ContextExporter.java
+++ b/report-model/src/main/java/eu/tsystems/mms/tic/testframework/adapters/ContextExporter.java
@@ -24,7 +24,7 @@ package eu.tsystems.mms.tic.testframework.adapters;
 import com.google.common.net.MediaType;
 import com.google.gson.Gson;
 import eu.tsystems.mms.tic.testframework.logging.Loggable;
-import eu.tsystems.mms.tic.testframework.report.DefaultReport;
+import eu.tsystems.mms.tic.testframework.report.Report;
 import eu.tsystems.mms.tic.testframework.report.TesterraListener;
 import eu.tsystems.mms.tic.testframework.report.model.ClickPathEvent;
 import eu.tsystems.mms.tic.testframework.internal.IDUtils;
@@ -70,8 +70,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Level;
 
 public class ContextExporter implements Loggable {
-    private static final Map<TestStatusController.Status, ResultStatusType> STATUS_MAPPING = new LinkedHashMap<>();
-    private final DefaultReport report = (DefaultReport)TesterraListener.getReport();
+    private final Map<TestStatusController.Status, ResultStatusType> STATUS_MAPPING = new LinkedHashMap<>();
+    private final Report report = TesterraListener.getReport();
     private final Gson jsonEncoder = new Gson();
 
 //    private Map<String,Object> getAnnotationParameters(Annotation annotation) {


### PR DESCRIPTION
# Description

Moves methods from `DefaultReport` implementation to `Report` interface.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
