### PR TITLE
tt.browser.setting sets tt.browser and tt.browser.version as well

### DIFF
--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/AbstractWebDriverConfiguration.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/AbstractWebDriverConfiguration.java
@@ -20,6 +20,8 @@
  */
 package eu.tsystems.mms.tic.testframework.webdrivermanager;
 
+import eu.tsystems.mms.tic.testframework.common.PropertyManager;
+import eu.tsystems.mms.tic.testframework.constants.TesterraProperties;
 import java.io.Serializable;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -35,6 +37,7 @@ public abstract class AbstractWebDriverConfiguration implements Serializable {
     }
 
     public AbstractWebDriverConfiguration setBrowser(String browser) {
+        PropertyManager.getThreadLocalProperties().setProperty(TesterraProperties.BROWSER, browser);
         this.browser = browser;
         return this;
     }
@@ -44,6 +47,7 @@ public abstract class AbstractWebDriverConfiguration implements Serializable {
     }
 
     public AbstractWebDriverConfiguration setBrowserVersion(String browserVersion) {
+        PropertyManager.getThreadLocalProperties().setProperty(TesterraProperties.BROWSER_VERSION, browserVersion);
         this.browserVersion = browserVersion;
         return this;
     }

--- a/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/webdrivermanager/WebDriverManagerTest.java
+++ b/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/webdrivermanager/WebDriverManagerTest.java
@@ -29,6 +29,7 @@ import eu.tsystems.mms.tic.testframework.report.model.context.SessionContext;
 import eu.tsystems.mms.tic.testframework.report.utils.ExecutionContextController;
 import eu.tsystems.mms.tic.testframework.webdrivermanager.DesktopWebDriverRequest;
 import eu.tsystems.mms.tic.testframework.webdrivermanager.WebDriverManager;
+import eu.tsystems.mms.tic.testframework.webdrivermanager.WebDriverManagerConfig;
 import eu.tsystems.mms.tic.testframework.webdrivermanager.WebDriverSessionsManager;
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.WebDriver;
@@ -186,5 +187,14 @@ public class WebDriverManagerTest extends AbstractWebDriverTest {
         Assert.assertEquals(size.getWidth(), expected.getWidth());
         Assert.assertEquals(size.getHeight(), expected.getHeight());
         WebDriverManager.shutdown();
+    }
+
+    @Test
+    public void test_propagatedBrowserSettingProperty() {
+        PropertyManager.getThreadLocalProperties().setProperty(TesterraProperties.BROWSER_SETTING, "mybrowser:myversion");
+        WebDriverManager.getConfig().reset();
+        Assert.assertEquals(WebDriverManager.getConfig().getBrowser(), "mybrowser");
+        Assert.assertEquals(PropertyManager.getProperty(TesterraProperties.BROWSER), "mybrowser");
+        Assert.assertEquals( PropertyManager.getProperty(TesterraProperties.BROWSER_VERSION), "myversion");
     }
 }


### PR DESCRIPTION
# Description

Setting `tt.browser.setting` also sets thread local properties for `tt.browser` and `tt.browser.version`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
