### PR TITLE
Fixed copying clipboard when application runs in frames

### DIFF
--- a/report-ng/app/package-lock.json
+++ b/report-ng/app/package-lock.json
@@ -13315,9 +13315,9 @@
             "dev": true
         },
         "node_modules/t-systems-aurelia-components": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/t-systems-aurelia-components/-/t-systems-aurelia-components-1.0.10.tgz",
-            "integrity": "sha512-g89GFSiws3bHqGqA7IshqnbiJe9SP8M+UjLDS0mrL+fMc088TJqtgw6C3N/oAVW7NrpbqeLmUJD4D0Oz8cfqaQ=="
+            "version": "1.0.12",
+            "resolved": "https://registry.npmjs.org/t-systems-aurelia-components/-/t-systems-aurelia-components-1.0.12.tgz",
+            "integrity": "sha512-i8xQapX1JDV4xprr8R0QaDapeXKV7YSwwUlVneRdxnDUjT6wPJ3J7MQfBGkDtsJnrrFIduwDvayL+N7YVElueg=="
         },
         "node_modules/tapable": {
             "version": "1.1.3",
@@ -26644,9 +26644,9 @@
             "dev": true
         },
         "t-systems-aurelia-components": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/t-systems-aurelia-components/-/t-systems-aurelia-components-1.0.10.tgz",
-            "integrity": "sha512-g89GFSiws3bHqGqA7IshqnbiJe9SP8M+UjLDS0mrL+fMc088TJqtgw6C3N/oAVW7NrpbqeLmUJD4D0Oz8cfqaQ=="
+            "version": "1.0.12",
+            "resolved": "https://registry.npmjs.org/t-systems-aurelia-components/-/t-systems-aurelia-components-1.0.12.tgz",
+            "integrity": "sha512-i8xQapX1JDV4xprr8R0QaDapeXKV7YSwwUlVneRdxnDUjT6wPJ3J7MQfBGkDtsJnrrFIduwDvayL+N7YVElueg=="
         },
         "tapable": {
             "version": "1.1.3",

--- a/report-ng/app/src/components/method-details/details.ts
+++ b/report-ng/app/src/components/method-details/details.ts
@@ -36,6 +36,7 @@ import {data} from "../../services/report-model";
 import {MdcSnackbarService} from '@aurelia-mdc-web/snackbar';
 import IStackTraceCause = data.IStackTraceCause;
 import {ILayoutComparisonContext} from "../layout-comparison/layout-comparison";
+import {Clipboard} from "t-systems-aurelia-components/src/utils/clipboard";
 
 @autoinject()
 export class Details {
@@ -69,11 +70,11 @@ export class Details {
 
     private _copyStackTraceToClipboard(stackTrace:IStackTraceCause[]) {
         const msg = stackTrace.flatMap(cause => cause.stackTraceElements).join("\n");
-        navigator.clipboard.writeText(msg).then(response => {
+
+        const clipboard = new Clipboard();
+        clipboard.writeText(msg).then(() => {
             this._snackbarNotification('Stacktrace copied to clipboard');
         });
-
-
     }
 
     private async _snackbarNotification(message: string) {


### PR DESCRIPTION
# Description

Fixes not working "copy to clipboard" feature in report-ng when the application run within frames.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
