### PR TITLE
Added event for clearing PageFactory loop detection buffer after method end

### DIFF
--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/execution/worker/finish/PageFactoryBufferWorker.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/execution/worker/finish/PageFactoryBufferWorker.java
@@ -1,0 +1,24 @@
+package eu.tsystems.mms.tic.testframework.execution.worker.finish;
+
+import com.google.common.eventbus.Subscribe;
+import eu.tsystems.mms.tic.testframework.events.MethodEndEvent;
+import eu.tsystems.mms.tic.testframework.pageobjects.factory.PageFactory;
+
+/**
+ * Created on 28.01.2022
+ *
+ * @author mgn
+ */
+public class PageFactoryBufferWorker implements MethodEndEvent.Listener {
+
+    /**
+     * Clear the PageFactory Loop detection buffer at the end of every method
+     *
+     * @param event
+     */
+    @Override
+    @Subscribe
+    public void onMethodEnd(MethodEndEvent event) {
+        PageFactory.clearLoopDetectionBuffer();
+    }
+}

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/hooks/DriverUiHook.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/hooks/DriverUiHook.java
@@ -27,6 +27,7 @@ import eu.tsystems.mms.tic.testframework.constants.TesterraProperties;
 import eu.tsystems.mms.tic.testframework.execution.testng.RetryAnalyzer;
 import eu.tsystems.mms.tic.testframework.execution.testng.WebDriverRetryAnalyzer;
 import eu.tsystems.mms.tic.testframework.execution.worker.finish.ConditionalBehaviourWorker;
+import eu.tsystems.mms.tic.testframework.execution.worker.finish.PageFactoryBufferWorker;
 import eu.tsystems.mms.tic.testframework.execution.worker.finish.TakeInSessionEvidencesWorker;
 import eu.tsystems.mms.tic.testframework.execution.worker.finish.WebDriverShutDownWorker;
 import eu.tsystems.mms.tic.testframework.execution.worker.start.PerformanceTestWorker;
@@ -68,6 +69,9 @@ public class DriverUiHook implements ModuleHook {
          */
         eventBus.register(new WebDriverShutDownWorker());
         eventBus.register(new ShutdownSessionsListener());
+
+        // Clear PageFactory loop detection buffer
+        eventBus.register(new PageFactoryBufferWorker());
 
         /*
         register services

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/factory/PageFactory.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/factory/PageFactory.java
@@ -19,22 +19,20 @@
  * under the License.
  *
  */
- package eu.tsystems.mms.tic.testframework.pageobjects.factory;
+package eu.tsystems.mms.tic.testframework.pageobjects.factory;
 
 import eu.tsystems.mms.tic.testframework.common.PropertyManager;
 import eu.tsystems.mms.tic.testframework.constants.TesterraProperties;
-import eu.tsystems.mms.tic.testframework.pageobjects.AbstractPage;
 import eu.tsystems.mms.tic.testframework.pageobjects.Page;
 import eu.tsystems.mms.tic.testframework.pageobjects.PageVariables;
-import eu.tsystems.mms.tic.testframework.report.model.context.MethodContext;
-import eu.tsystems.mms.tic.testframework.report.utils.ExecutionContextController;
-import eu.tsystems.mms.tic.testframework.utils.StringUtils;
+import org.apache.commons.collections.buffer.CircularFifoBuffer;
+import org.apache.commons.lang3.StringUtils;
+import org.openqa.selenium.WebDriver;
+
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.commons.collections.buffer.CircularFifoBuffer;
-import org.openqa.selenium.WebDriver;
 
 public final class PageFactory {
 
@@ -51,12 +49,8 @@ public final class PageFactory {
     private static String GLOBAL_PAGES_PREFIX = null;
     private static ThreadLocal<String> THREAD_LOCAL_PAGES_PREFIX = new ThreadLocal<>();
 
-    /**
-     * This loop detection feature is obsolete as soon {@link AbstractPage#checkPage()} is no more part of a public API
-     */
-    @Deprecated
     private static final ThreadLocal<CircularFifoBuffer> LOOP_DETECTION_LOGGER = new ThreadLocal<>();
-    @Deprecated
+
     private static final int NR_OF_LOOPS = PropertyManager.getIntProperty(TesterraProperties.PAGE_FACTORY_LOOPS, 20);
 
     private PageFactory() {
@@ -112,7 +106,7 @@ public final class PageFactory {
         find matching implementing class
          */
         String pagesPrefix = GLOBAL_PAGES_PREFIX;
-        if (!StringUtils.isStringEmpty(THREAD_LOCAL_PAGES_PREFIX.get())) {
+        if (StringUtils.isNotEmpty(THREAD_LOCAL_PAGES_PREFIX.get())) {
             pagesPrefix = THREAD_LOCAL_PAGES_PREFIX.get();
         }
         pageClass = ClassFinder.getBestMatchingClass(pageClass, driver, pagesPrefix);
@@ -186,6 +180,10 @@ public final class PageFactory {
         }
 
         return t;
+    }
+
+    public static void clearLoopDetectionBuffer() {
+        LOOP_DETECTION_LOGGER.get().clear();
     }
 
     public static void clearCache() {

--- a/integration-tests/src/test/resources/test.properties
+++ b/integration-tests/src/test/resources/test.properties
@@ -34,6 +34,9 @@ tt.failure.corridor.allowed.failed.tests.high=0
 tt.failure.corridor.allowed.failed.tests.mid=0
 tt.failure.corridor.allowed.failed.tests.low=0
 
+# Needed for PageFactoryTest
+tt.page.factory.loops=5
+
 test=huhu
 
 fileName=index.html


### PR DESCRIPTION
# Description

The buffer for the PageFactory loop detection buffer was not cleared over the whole test execution. In rare cases like non-parallel dataprovider tests with only one page you have to extend the Testerra property `tt.page.factory.loops`.

With this change the internal buffer is cleared after the method end event. Only within a method there is a default limit of 20 when you create a page of the same type in a row.

Fixes #201 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
