### PR TITLE
Fixed handling if dataprovider method failed

### DIFF
--- a/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/playground/ReportingAllStatesTests.java
+++ b/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/playground/ReportingAllStatesTests.java
@@ -23,19 +23,14 @@ package eu.tsystems.mms.tic.testframework.playground;
 
 import eu.tsystems.mms.tic.testframework.AbstractWebDriverTest;
 import eu.tsystems.mms.tic.testframework.annotations.Fails;
-import eu.tsystems.mms.tic.testframework.annotations.InDevelopment;
 import eu.tsystems.mms.tic.testframework.annotations.InfoMethod;
-import eu.tsystems.mms.tic.testframework.annotations.New;
-import eu.tsystems.mms.tic.testframework.annotations.ReadyForApproval;
-import eu.tsystems.mms.tic.testframework.annotations.SupportMethod;
 import eu.tsystems.mms.tic.testframework.annotations.TestClassContext;
 import eu.tsystems.mms.tic.testframework.execution.testng.AssertCollector;
-import eu.tsystems.mms.tic.testframework.execution.testng.NonFunctionalAssert;
+import eu.tsystems.mms.tic.testframework.execution.testng.OptionalAssert;
 import eu.tsystems.mms.tic.testframework.transfer.ThrowablePackedResponse;
 import eu.tsystems.mms.tic.testframework.utils.RandomUtils;
 import eu.tsystems.mms.tic.testframework.utils.Timer;
 import eu.tsystems.mms.tic.testframework.utils.TimerUtils;
-import java.lang.reflect.Method;
 import org.openqa.selenium.WebDriverException;
 import org.testng.Assert;
 import org.testng.SkipException;
@@ -45,6 +40,8 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Optional;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
+
+import java.lang.reflect.Method;
 
 @TestClassContext(name = "MyClass")
 public class ReportingAllStatesTests extends AbstractWebDriverTest {
@@ -69,7 +66,7 @@ public class ReportingAllStatesTests extends AbstractWebDriverTest {
                 AssertCollector.assertEquals(2, 1, "late fail");
                 break;
             case MINOR:
-                NonFunctionalAssert.assertEquals(2, 1, "minor fail");
+                OptionalAssert.assertEquals(2, 1, "minor fail");
                 break;
             case RETRY:
                 throw new WebDriverException("Error communicating with the remote browser. It may have died.");
@@ -92,7 +89,7 @@ public class ReportingAllStatesTests extends AbstractWebDriverTest {
         int size = 20;
         Object[][] objects = new Object[size][1];
         for (int i = 0; i < size; i++) {
-            objects[i][0] = "" + (i+1);
+            objects[i][0] = "" + (i + 1);
         }
         return objects;
     }
@@ -296,7 +293,6 @@ public class ReportingAllStatesTests extends AbstractWebDriverTest {
         throw new WebDriverException("Error communicating with the remote browser. It may have died.");
     }
 
-
     @Test
     public void testNewRun() throws Exception {
 
@@ -315,26 +311,6 @@ public class ReportingAllStatesTests extends AbstractWebDriverTest {
         TimerUtils.sleep(RandomUtils.generateRandomInt(20));
 
         failingStep(How.RETRY);
-    }
-
-    @New
-    @Test
-    public void testNew() {}
-
-    @ReadyForApproval
-    @Test
-    public void testRFA() {}
-
-    @New
-    @ReadyForApproval
-    @Test
-    public void testNewRFA() {}
-
-    @New
-    @ReadyForApproval
-    @Test
-    public void testNewRFAFailing() {
-        failingStep(How.FAST);
     }
 
     @Test
@@ -369,20 +345,6 @@ public class ReportingAllStatesTests extends AbstractWebDriverTest {
     }
 
     @Test
-    @SupportMethod
-    @New
-    @ReadyForApproval
-    @InDevelopment
-    public void testAllMarkers() throws Exception {
-    }
-
-    @InDevelopment
-    @Test
-    public void testInDevelopment() {
-
-    }
-
-    @Test
     public void testAssertCollector() {
         AssertCollector.fail("failed1");
         AssertCollector.fail("failed2");
@@ -393,9 +355,4 @@ public class ReportingAllStatesTests extends AbstractWebDriverTest {
     public void beforeMethod(Method method) {
     }
 
-    @InfoMethod
-    @Test
-    public void testInfo() {
-
-    }
 }

--- a/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/playground/SetupFailedTests.java
+++ b/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/playground/SetupFailedTests.java
@@ -1,0 +1,97 @@
+/*
+ * Testerra
+ *
+ * (C) 2022, Martin Großmann, T-Systems Multimedia Solutions GmbH, Deutsche Telekom AG
+ *
+ * Deutsche Telekom AG and all other contributors /
+ * copyright owners license this file to you under the Apache
+ * License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package eu.tsystems.mms.tic.testframework.playground;
+
+import eu.tsystems.mms.tic.testframework.AbstractWebDriverTest;
+import eu.tsystems.mms.tic.testframework.execution.testng.OptionalAssert;
+import eu.tsystems.mms.tic.testframework.logging.Loggable;
+import eu.tsystems.mms.tic.testframework.testing.TesterraTest;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Created on 10.03.2022
+ *
+ * @author mgn
+ */
+public class SetupFailedTests extends TesterraTest implements Loggable {
+
+    @DataProvider(name = "dpAssertFailed")
+    public Object[][] dpAssertFailedMethod() {
+        Object[][] objects = new Object[1][1];
+        Assert.fail("Failed assertion in Dataprovider");
+        return objects;
+    }
+
+    @Test(dataProvider = "dpAssertFailed")
+    public void testDpAssertFailed(String dp) throws Exception {
+
+    }
+
+    @DataProvider(name = "dpAssertPassed")
+    public Object[][] dpAssertPassedMethod() {
+        Object[][] objects = new Object[1][1];
+        Assert.assertTrue(true, "Passed assertion in Dataprovider");
+        return objects;
+    }
+
+    @Test(dataProvider = "dpAssertPassed")
+    public void testDpAssertPassed(String dp) throws Exception {
+        log().info("Test case passed");
+    }
+
+    @DataProvider(name = "dpOptionalAssertFailed")
+    public Object[][] dpOptionalAssertFailed() {
+        Object[][] objects = new Object[1][1];
+        // TODO: This otpional assert cannot store because at this time no method context is created
+        OptionalAssert.assertTrue(false, "Failed optional assertion in Dataprovider");
+        return objects;
+    }
+
+    @Test(dataProvider = "dpOptionalAssertFailed")
+    public void testDpOptionalAssertFailed(String dp) throws Exception {
+
+    }
+
+    @DataProvider(name = "dpException")
+    public Object[][] dpExecption() {
+        throw new RuntimeException("Exception in Dataprovider");
+    }
+
+    @Test(dataProvider = "dpException")
+    public void testDpException(String dp) throws Exception {
+
+    }
+
+//    @BeforeMethod(groups = "failedGroup1")
+//    public void beforeMethod() {
+//        Assert.fail("Failed assertion in setup method");
+//    }
+//
+//    @Test(groups = "failedGroup1")
+//    public void testFailedBeforeMethod() {
+//
+//    }
+
+}


### PR DESCRIPTION
# Description

In case of a failed data provider method the method context for the corresponding test method has the state `SKIPPED` and contains the assertion or exception of data provider method.

Note: See #215 for improvement of data provider methods.

Fixes #214 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
