### PR TITLE
Fixed hasWords assertion of strings

### DIFF
--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/DefaultStringAssertion.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/DefaultStringAssertion.java
@@ -124,40 +124,7 @@ public class DefaultStringAssertion<T> extends DefaultQuantityAssertion<T> imple
                 return "has words " + Format.param(wordsList);
             }
         });
-
-//        AtomicInteger found = new AtomicInteger();
-//        words.forEach(word -> {
-//            /*
-//            Non-word characters have an impact to word boundary regex '\b'
-//            If word contains non-word characters, assertion falls back to string.contains()
-//            */
-//            final Pattern wordBoundCharPattern = Pattern.compile("\\W");
-//            Matcher charMatcher = wordBoundCharPattern.matcher(word);
-//            if (!charMatcher.find()) {
-//                final Pattern wordBoundaryPattern = Pattern.compile("\\b(" + word + ")\\b", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
-//                Matcher wordMatcher = wordBoundaryPattern.matcher(provider.getActual().toString());
-//                if (wordMatcher.find()) {
-//                    found.incrementAndGet();
-//                }
-//            } else {
-//                log().warn("'{}' contains non-word characters. 'hasWords()' assertion falls back to string.contains()", word);
-//                if (provider.getActual().toString().toLowerCase().contains(word.toLowerCase())) {
-//                    found.incrementAndGet();
-//                }
-//            }
-//        });
-//
-//        return propertyAssertionFactory.createWithParent(DefaultBinaryAssertion.class, this, new AssertionProvider<Boolean>() {
-//            @Override
-//            public Boolean getActual() {
-//                return found.get() == words.size();
-//            }
-//
-//            @Override
-//            public String createSubject() {
-//                return "has words " + Format.param(String.join("|", words));
-//            }
-//        });
+        
     }
 
     @Override

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/DefaultStringAssertion.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/DefaultStringAssertion.java
@@ -124,7 +124,6 @@ public class DefaultStringAssertion<T> extends DefaultQuantityAssertion<T> imple
                 return "has words " + Format.param(wordsList);
             }
         });
-        
     }
 
     @Override

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/DefaultStringAssertion.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/DefaultStringAssertion.java
@@ -24,9 +24,9 @@ package eu.tsystems.mms.tic.testframework.internal.asserts;
 import eu.tsystems.mms.tic.testframework.logging.Loggable;
 
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Default implementation of {@link StringAssertion}
@@ -101,40 +101,63 @@ public class DefaultStringAssertion<T> extends DefaultQuantityAssertion<T> imple
 
     @Override
     public BinaryAssertion<Boolean> hasWords(List<String> words) {
+        final Pattern nonWordAtBegin = Pattern.compile("^\\W");
+        final Pattern nonWordAtTheEnd = Pattern.compile("\\W$");
 
-        AtomicInteger found = new AtomicInteger();
-        words.forEach(word -> {
-            /*
-            Non-word characters have an impact to word boundary regex '\b'
-            If word contains non-word characters, assertion falls back to string.contains()
-            */
-            final Pattern wordBoundCharPattern = Pattern.compile("\\W");
-            Matcher charMatcher = wordBoundCharPattern.matcher(word);
-            if (!charMatcher.find()) {
-                final Pattern wordBoundaryPattern = Pattern.compile("\\b(" + word + ")\\b", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
-                Matcher wordMatcher = wordBoundaryPattern.matcher(provider.getActual().toString());
-                if (wordMatcher.find()) {
-                    found.incrementAndGet();
-                }
-            } else {
-                log().warn("'{}' contains non-word characters. 'hasWords()' assertion falls back to string.contains()", word);
-                if (provider.getActual().toString().toLowerCase().contains(word.toLowerCase())) {
-                    found.incrementAndGet();
-                }
-            }
-        });
+        final String wordsList = words.stream()
+                .map(word -> (nonWordAtBegin.matcher(word).find() ? "\\B" : "\\b") + "\\Q" + word) // word boundary for begin
+                .map(word -> word + "\\E" + (nonWordAtTheEnd.matcher(word).find() ? "\\B" : "\\b")) // word boundary for end
+                .collect(Collectors.joining("|"));
+        final Pattern wordsPattern = Pattern.compile(wordsList, Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
 
         return propertyAssertionFactory.createWithParent(DefaultBinaryAssertion.class, this, new AssertionProvider<Boolean>() {
             @Override
             public Boolean getActual() {
-                return found.get() == words.size();
+                int found = 0;
+                Matcher matcher = wordsPattern.matcher(provider.getActual().toString());
+                while (matcher.find()) found++;
+                return found == words.size();
             }
 
             @Override
             public String createSubject() {
-                return "has words " + Format.param(String.join("|", words));
+                return "has words " + Format.param(wordsList);
             }
         });
+
+//        AtomicInteger found = new AtomicInteger();
+//        words.forEach(word -> {
+//            /*
+//            Non-word characters have an impact to word boundary regex '\b'
+//            If word contains non-word characters, assertion falls back to string.contains()
+//            */
+//            final Pattern wordBoundCharPattern = Pattern.compile("\\W");
+//            Matcher charMatcher = wordBoundCharPattern.matcher(word);
+//            if (!charMatcher.find()) {
+//                final Pattern wordBoundaryPattern = Pattern.compile("\\b(" + word + ")\\b", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
+//                Matcher wordMatcher = wordBoundaryPattern.matcher(provider.getActual().toString());
+//                if (wordMatcher.find()) {
+//                    found.incrementAndGet();
+//                }
+//            } else {
+//                log().warn("'{}' contains non-word characters. 'hasWords()' assertion falls back to string.contains()", word);
+//                if (provider.getActual().toString().toLowerCase().contains(word.toLowerCase())) {
+//                    found.incrementAndGet();
+//                }
+//            }
+//        });
+//
+//        return propertyAssertionFactory.createWithParent(DefaultBinaryAssertion.class, this, new AssertionProvider<Boolean>() {
+//            @Override
+//            public Boolean getActual() {
+//                return found.get() == words.size();
+//            }
+//
+//            @Override
+//            public String createSubject() {
+//                return "has words " + Format.param(String.join("|", words));
+//            }
+//        });
     }
 
     @Override

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/DefaultStringAssertion.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/DefaultStringAssertion.java
@@ -22,16 +22,17 @@
 package eu.tsystems.mms.tic.testframework.internal.asserts;
 
 import eu.tsystems.mms.tic.testframework.logging.Loggable;
+
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
  * Default implementation of {@link StringAssertion}
+ *
  * @author Mike Reiche
  */
 public class DefaultStringAssertion<T> extends DefaultQuantityAssertion<T> implements StringAssertion<T>, Loggable {
-
 
     public DefaultStringAssertion(AbstractPropertyAssertion parentAssertion, AssertionProvider<T> provider) {
         super(parentAssertion, provider);
@@ -100,7 +101,14 @@ public class DefaultStringAssertion<T> extends DefaultQuantityAssertion<T> imple
     @Override
     public BinaryAssertion<Boolean> hasWords(List<String> words) {
         final String wordsList = String.join("|", words);
-        final Pattern wordsPattern = Pattern.compile("\\b(" + wordsList + ")\\b", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
+        final String wordsListPattern = "\\b("
+                + wordsList
+                .replace("(", "\\(")
+                .replace(")", "\\)")
+                .replace("[", "\\[")
+                .replace("]", "\\]")
+                + ")";
+        final Pattern wordsPattern = Pattern.compile(wordsListPattern, Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
 
         return propertyAssertionFactory.createWithParent(DefaultBinaryAssertion.class, this, new AssertionProvider<Boolean>() {
             @Override
@@ -117,7 +125,6 @@ public class DefaultStringAssertion<T> extends DefaultQuantityAssertion<T> imple
             }
         });
     }
-
 
     @Override
     public QuantityAssertion<Integer> length() {

--- a/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/guielement/UiElementActionTests.java
+++ b/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/guielement/UiElementActionTests.java
@@ -24,7 +24,6 @@ import eu.tsystems.mms.tic.testframework.AbstractExclusiveTestSitesTest;
 import eu.tsystems.mms.tic.testframework.common.Testerra;
 import eu.tsystems.mms.tic.testframework.core.pageobjects.testdata.WebTestPage;
 import eu.tsystems.mms.tic.testframework.exceptions.TimeoutException;
-import eu.tsystems.mms.tic.testframework.pageobjects.Attribute;
 import eu.tsystems.mms.tic.testframework.pageobjects.UiElement;
 import eu.tsystems.mms.tic.testframework.testing.AssertProvider;
 import eu.tsystems.mms.tic.testframework.testing.TestController;

--- a/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/guielement/UiElementCommonTests.java
+++ b/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/guielement/UiElementCommonTests.java
@@ -27,6 +27,7 @@ import eu.tsystems.mms.tic.testframework.exceptions.ElementNotFoundException;
 import eu.tsystems.mms.tic.testframework.exceptions.UiElementAssertionError;
 import eu.tsystems.mms.tic.testframework.internal.asserts.ImageAssertion;
 import eu.tsystems.mms.tic.testframework.pageobjects.UiElement;
+import eu.tsystems.mms.tic.testframework.pageobjects.XPath;
 import eu.tsystems.mms.tic.testframework.testing.AssertProvider;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -103,6 +104,22 @@ public class UiElementCommonTests extends AbstractExclusiveTestSitesTest<WebTest
         UiElement empty = getPage().getFinder().createEmpty().setName("SubmitButton");
         empty.expect().displayed(true);
         Assert.assertEquals(empty.toString(true), "WebTestPage -> EmptyUiElement(SubmitButton)");
+    }
+
+    @Test
+    public void testT10_UiElement_text_assert() {
+        WebTestPage page = getPage();
+        UiElement element = page.getFinder().find(XPath.from("label").text().hasWords("TimeOut in Millis (0-inf)"));
+        element.expect().text().hasWords("TimeOut in Millis (0-inf)").is(true);
+        element.expect().text().hasWords("TimeOut in Millis").is(true);
+        element.expect().text().hasWords("0-inf)").is(true);
+        element.expect().text().hasWords("TimeOut in Millis".split("\\s+")).is(true);
+        element.expect().text().hasWords("TimeOut", "in", "Millis").is(true);
+
+        element.expect().text().hasWords("Out").is(false);
+
+
+
     }
 
 }

--- a/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/guielement/UiElementCommonTests.java
+++ b/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/guielement/UiElementCommonTests.java
@@ -112,7 +112,7 @@ public class UiElementCommonTests extends AbstractExclusiveTestSitesTest<WebTest
         UiElement element = page.getFinder().find(XPath.from("label").text().hasWords("TimeOut in Millis (0-inf)"));
         element.expect().text().hasWords("TimeOut in Millis (0-inf)").is(true);
         element.expect().text().hasWords("TimeOut in Millis").is(true);
-        element.expect().text().hasWords("0-inf)").is(true);
+        element.expect().text().hasWords("(0-inf)").is(true);
         element.expect().text().hasWords("TimeOut in Millis".split("\\s+")).is(true);
         element.expect().text().hasWords("TimeOut", "in", "Millis").is(true);
         element.expect().text().hasWords("tIMEoUT", "iN", "mILLIS").is(true);

--- a/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/guielement/UiElementCommonTests.java
+++ b/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/guielement/UiElementCommonTests.java
@@ -119,6 +119,7 @@ public class UiElementCommonTests extends AbstractExclusiveTestSitesTest<WebTest
         element.expect().text().hasWords("tIMEoUT in mILLIS").is(true);
 
         element.expect().text().hasWords("Out").is(false);
+        element.expect().text().hasWords("TimeOut", "in", "foo").is(false);
 
 
 

--- a/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/guielement/UiElementCommonTests.java
+++ b/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/guielement/UiElementCommonTests.java
@@ -115,6 +115,8 @@ public class UiElementCommonTests extends AbstractExclusiveTestSitesTest<WebTest
         element.expect().text().hasWords("0-inf)").is(true);
         element.expect().text().hasWords("TimeOut in Millis".split("\\s+")).is(true);
         element.expect().text().hasWords("TimeOut", "in", "Millis").is(true);
+        element.expect().text().hasWords("tIMEoUT", "iN", "mILLIS").is(true);
+        element.expect().text().hasWords("tIMEoUT in mILLIS").is(true);
 
         element.expect().text().hasWords("Out").is(false);
 

--- a/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/guielement/UiElementCommonTests.java
+++ b/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/guielement/UiElementCommonTests.java
@@ -120,9 +120,6 @@ public class UiElementCommonTests extends AbstractExclusiveTestSitesTest<WebTest
 
         element.expect().text().hasWords("Out").is(false);
         element.expect().text().hasWords("TimeOut", "in", "foo").is(false);
-
-
-
     }
 
 }


### PR DESCRIPTION
# Description

Changed the implementation of `hasWords()` assertion:

- Handle every element of the given list of words
- Check non word characters with "\W"
  - false:  check with `\b<word>\b`
  - true: non-word characters have an impact to `\b` -> fallback to `string.contains(word)`
- count of findings = words.size() -> assertion passed

Fixes #233 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
