### PR TITLE
fix to display innerhtml in Priority messages of the method view

### DIFF
--- a/report-ng/app/src/components/method-details/method.html
+++ b/report-ng/app/src/components/method-details/method.html
@@ -131,7 +131,10 @@
                             class.bind="(logMessage.type===1?'status-failed':(logMessage.type===2?'status-skipped':''))"
                             repeat.for="logMessage of _methodDetails.promptLogs"
                         >
-                            <span lass="two-lines"><class-name-markup namespace.bind="logMessage.loggerName">:</class-name-markup>${logMessage.message|html}</span>
+                            <span lass="two-lines" >
+                                <class-name-markup namespace.bind="logMessage.loggerName">:</class-name-markup>
+                                <span innerhtml.bind="logMessage.message|html"></span>
+                            </span>
                         </li>
                     </ul>
                 </mdc-card>


### PR DESCRIPTION
# Description

Previously links where automatically parsed and a link was created for them. The resulting html was then escaped in the report so you would see things like <a href="example.com">example.com</a> instead of a link to example.com.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
