### PR TITLE
show message for failed validation in expected fails

### DIFF
--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/report/FailsAnnotationConverter.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/report/FailsAnnotationConverter.java
@@ -32,16 +32,16 @@ public class FailsAnnotationConverter implements AnnotationConverter<Fails> {
     @Override
     public Map<String, Object> toMap(Fails annotation) {
         Map<String, Object> map = new HashMap<>();
-        if (!StringUtils.isBlank(annotation.description())) {
+        if (StringUtils.isNotBlank(annotation.description())) {
             map.put("description", annotation.description());
         }
-        if (!StringUtils.isBlank(annotation.ticketString())) {
+        if (StringUtils.isNotBlank(annotation.ticketString())) {
             map.put("ticketString", annotation.ticketString());
         } else if (annotation.ticketId() > 0) {
             map.put("ticketString", Integer.toString(annotation.ticketId()));
         }
-        if(!StringUtils.isBlank(annotation.validator())) {
-            map.put("validator", annotation.validatorClass().getCanonicalName() +"."+ annotation.validator());
+        if (StringUtils.isNotBlank(annotation.validator())) {
+            map.put("validator", annotation.validatorClass().getCanonicalName() + "." + annotation.validator());
         }
         return map;
     }

--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/report/FailsAnnotationConverter.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/report/FailsAnnotationConverter.java
@@ -40,6 +40,9 @@ public class FailsAnnotationConverter implements AnnotationConverter<Fails> {
         } else if (annotation.ticketId() > 0) {
             map.put("ticketString", Integer.toString(annotation.ticketId()));
         }
+        if(!StringUtils.isBlank(annotation.validator())) {
+            map.put("validator", annotation.validatorClass().getCanonicalName() +"."+ annotation.validator());
+        }
         return map;
     }
 }

--- a/report-ng/app/src/components/method-details/method.html
+++ b/report-ng/app/src/components/method-details/method.html
@@ -59,8 +59,9 @@
                     >
                         <span class="badge status-failed-expected sr1">@Fails</span>
                         <div>
-                            <div if.bind="_methodDetails.failsAnnotation.description">${_methodDetails.failsAnnotation.description}</div>
-                            <div if.bind="_methodDetails.failsAnnotation.ticketString">Ticket: <span innerhtml.bind="_methodDetails.failsAnnotation.ticketString|html"></span></div>
+                            <div if.bind="_methodDetails.failsAnnotation.description&&7!= _methodDetails.methodContext.resultStatus">${_methodDetails.failsAnnotation.description}</div>
+                            <div if.bind="_methodDetails.failsAnnotation.ticketString&&7!= _methodDetails.methodContext.resultStatus">Ticket: <span innerhtml.bind="_methodDetails.failsAnnotation.ticketString|html"></span></div>
+                            <div if.bind="_methodDetails.failsAnnotation.validator&&7== _methodDetails.methodContext.resultStatus">Your conditions for Expected fails were not fulfilled: <br> ${_methodDetails.failsAnnotation.validator}</div>
                         </div>
                     </div>
                     <mdc-list-divider if.bind="_methodDetails.failsAnnotation"></mdc-list-divider>


### PR DESCRIPTION
# Description

Added the validator to the Mapping of the Fails annotation for the report and display it on failed test cases when the validation for the expected failure fails as well. This will also hide the description of the expected failure and the corresponding ticket string if they exist.

Fixes #175

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
