### PR TITLE
Added usage of `getActual` method for UiElements

### DIFF
--- a/docs/src/docs/guielement/guielement-properties.adoc
+++ b/docs/src/docs/guielement/guielement-properties.adoc
@@ -2,7 +2,7 @@
 
 == Use the `getActual()`
 
-The values of most properties of an UiElement can be returned by the `getActual()` method.
+The values of most properties of a UiElement can be returned by the `getActual()` method.
 
 .The given HTML snippet
 [source,html]

--- a/docs/src/docs/guielement/guielement-properties.adoc
+++ b/docs/src/docs/guielement/guielement-properties.adoc
@@ -2,7 +2,7 @@
 
 == Use the `getActual()`
 
-Most of all properties of a UiElement can be returned by the `getActual()` method.
+The values of most properties of an UiElement can be returned by the `getActual()` method.
 
 .The given HTML snippet
 [source,html]

--- a/docs/src/docs/guielement/guielement-properties.adoc
+++ b/docs/src/docs/guielement/guielement-properties.adoc
@@ -1,6 +1,29 @@
-= Access the WebElement
+= Properties
 
-UiElement provides all Selenium methods when retrieving the `WebElement`.
+== Use the `getActual()`
+
+Most of all properties of a UiElement can be returned by the `getActual()` method.
+
+.The given HTML snippet
+[source,html]
+----
+<a href="newpage.html" class="foolink" style="font-size: 20px;">My link</a>
+----
+
+[source,java]
+----
+UiElement element = find(By.xpath("//a"));
+
+String text = element.waitFor().text().getActual();             // returns "My link"
+String href = element.waitFor().attribute("href").getActual();  // returns "newpage.html"
+String tag = element.waitFor().tagName().getActual();           // returns "a"
+String classes = element.waitFor().classes().getActual();       // returns "foolink"
+String css = element.waitFor().css("font-size").getActual();    // returns "20px"
+----
+
+== Access the WebElement
+
+UiElement provides all Selenium methods when retrieving the `WebElement`. You have access to some more properties.
 
 .The given HTML snippet
 [source,html]
@@ -8,18 +31,21 @@ UiElement provides all Selenium methods when retrieving the `WebElement`.
 <a href="newpage.html" style="font-size: 20px;">My link</a>
 ----
 
-.Standard attributes
 [source,java]
 ----
 UiElement element = find(By.xpath("//a"));
 
 element.findWebElement(webElement -> {
-    String text = webElement.getText();                   // returns "My link"
-    String attr = webElement.getAttribute("href");        // returns "newpage.html"
-    String name = webElement.getTagName();                // returns "a"
-    Point point = webElement.getLocation();               // returns the top left corner of the element
-    Dimension dim = webElement.getSize();                 // returns width and heigth of the element
-    Rectangle rect = webElement.getRect();                // returns rectangle with location and size
-    String value = webElement.getCssValue("font-size");   // returns "20px"
+    Point point = webElement.getLocation();     // returns the top left corner of the element
+    Dimension dim = webElement.getSize();       // returns width and heigth of the element
+    Rectangle rect = webElement.getRect();      // returns rectangle with location and size
 });
 ----
+
+[IMPORTANT]
+====
+Testerra's UiElement does not support a public method like `element.getWebElement()` as `GuiElement` did this. Testerra wants to save you from a Selenium `StaleElementReferenceException`.
+
+We absolutely do not recommend to create you own Selenium WebElement by +
+`driver.findElement(By...)`. You fall back to plain Selenium and lose the Testerra error handling.
+====

--- a/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/playground/DriverAndGuiElementTest.java
+++ b/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/playground/DriverAndGuiElementTest.java
@@ -1,7 +1,7 @@
 /*
  * Testerra
  *
- * (C) 2020, Peter Lehmann, T-Systems Multimedia Solutions GmbH, Deutsche Telekom AG
+ * (C) 2022, Martin Großmann, T-Systems Multimedia Solutions GmbH, Deutsche Telekom AG
  *
  * Deutsche Telekom AG and all other contributors /
  * copyright owners license this file to you under the Apache
@@ -21,41 +21,38 @@
  */
  package eu.tsystems.mms.tic.testframework.playground;
 
+import eu.tsystems.mms.tic.testframework.AbstractTestSitesTest;
 import eu.tsystems.mms.tic.testframework.constants.Browsers;
 import eu.tsystems.mms.tic.testframework.core.pageobjects.testdata.PageWithExistingElement;
+import eu.tsystems.mms.tic.testframework.pageobjects.UiElement;
+import eu.tsystems.mms.tic.testframework.pageobjects.UiElementFinder;
 import eu.tsystems.mms.tic.testframework.pageobjects.factory.PageFactory;
 import eu.tsystems.mms.tic.testframework.report.model.context.SessionContext;
 import eu.tsystems.mms.tic.testframework.testing.TesterraTest;
+import eu.tsystems.mms.tic.testframework.testing.UiElementFinderFactoryProvider;
 import eu.tsystems.mms.tic.testframework.testing.WebDriverManagerProvider;
 import eu.tsystems.mms.tic.testframework.webdrivermanager.DesktopWebDriverRequest;
 import eu.tsystems.mms.tic.testframework.webdrivermanager.WebDriverSessionsManager;
 import eu.tsystems.mms.tic.testframework.webdrivermanager.desktop.WebDriverMode;
 import java.util.Map;
+
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-public class DriverAndGuiElementTest extends TesterraTest implements WebDriverManagerProvider {
-
-    static {
-        System.setProperty("tt.browser.setting", "firefox:66");
-    }
+public class DriverAndGuiElementTest extends AbstractTestSitesTest implements UiElementFinderFactoryProvider {
 
     @Test
-    public void testGuiElement() throws Exception {
-        DesktopWebDriverRequest request = new DesktopWebDriverRequest();
-        request.setBaseUrl(WEB_DRIVER_MANAGER.getConfig().getBaseUrl().orElse(null));
-        request.setWebDriverMode(WebDriverMode.local);
-        request.setBrowser(Browsers.phantomjs);
-        request.setBrowserVersion("egal");
+    public void testUiElement() throws Exception {
+        WebDriver driver = getWebDriver();
 
-//        DesiredCapabilities caps = new DesiredCapabilities();
-//        WebDriverManagerUtils.addProxyToCapabilities(caps, "proxyblabla");
-//        WebDriverManager.setGlobalExtraCapabilities(caps);
-
-        WebDriver driver = WEB_DRIVER_MANAGER.getWebDriver(request);
-        PageFactory.create(PageWithExistingElement.class, driver);
+        UiElementFinder uiElementFinder = UI_ELEMENT_FINDER_FACTORY.create(driver);
+        UiElement element = uiElementFinder.find(By.id("1"));
+        element.waitFor().attribute("href").getActual();
+        element.waitFor().tagName().getActual();
+        element.waitFor().classes().getActual();
     }
 
     @Test


### PR DESCRIPTION
# Description

The usage of the method `getActual()` to get current properties of UiElements was missing. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
