### PR TITLE
Fixed test status of optional in dataprovider test

### DIFF
--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/execution/testng/worker/finish/MethodContextUpdateWorker.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/execution/testng/worker/finish/MethodContextUpdateWorker.java
@@ -51,7 +51,9 @@ public class MethodContextUpdateWorker implements MethodEndEvent.Listener {
         ITestResult testResult = event.getTestResult();
 
         // Handle assertions and exceptions in dataprovider methods
-        if (testResult.getMethod().isDataDriven() && methodContext.readErrors().findFirst().isPresent()) {
+        if (testResult.getMethod().isDataDriven()
+                && methodContext.readErrors().findFirst().isPresent()
+                && methodContext.readErrors().anyMatch(ErrorContext::isNotOptional)) {
             testResult.setStatus(ITestResult.SKIP);
             methodContext.setStatus(Status.SKIPPED);
             StringBuilder sb = new StringBuilder();

--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/execution/testng/worker/finish/MethodContextUpdateWorker.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/execution/testng/worker/finish/MethodContextUpdateWorker.java
@@ -52,7 +52,6 @@ public class MethodContextUpdateWorker implements MethodEndEvent.Listener {
 
         // Handle assertions and exceptions in dataprovider methods
         if (testResult.getMethod().isDataDriven()
-                && methodContext.readErrors().findFirst().isPresent()
                 && methodContext.readErrors().anyMatch(ErrorContext::isNotOptional)) {
             testResult.setStatus(ITestResult.SKIP);
             methodContext.setStatus(Status.SKIPPED);

--- a/integration-tests/src/main/java/eu/tsystems/mms/tic/testframework/core/utils/Log4jFileReader.java
+++ b/integration-tests/src/main/java/eu/tsystems/mms/tic/testframework/core/utils/Log4jFileReader.java
@@ -27,7 +27,6 @@ import org.testng.Assert;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -140,10 +139,14 @@ public class Log4jFileReader implements Loggable {
     public void assertTestStatusPerMethod(final String classNameSlug, final String methodNameSlug, final Status expectedStatus) {
         final List<String> foundEntries = filterLogForTestMethod(classNameSlug, methodNameSlug);
 
-        for (final String entry : foundEntries) {
-            log().debug("Asserting '{}' for '{}'", expectedStatus, methodNameSlug);
-            Assert.assertTrue(entry.contains(expectedStatus.title), String.format("'%s' has status '%s'", methodNameSlug, expectedStatus));
-        }
+        log().debug("Asserting '{}' for '{}'", expectedStatus, methodNameSlug);
+        foundEntries.stream()
+                .filter(line -> line.contains(expectedStatus.title))
+                .findFirst()
+                .ifPresentOrElse(
+                        (value) -> log().info("Found status {}", expectedStatus.title),
+                        () -> Assert.fail(String.format("'%s' should have status '%s'", methodNameSlug, expectedStatus))
+                );
     }
 
     /**

--- a/integration-tests/src/main/java/eu/tsystems/mms/tic/testframework/core/utils/Log4jFileReader.java
+++ b/integration-tests/src/main/java/eu/tsystems/mms/tic/testframework/core/utils/Log4jFileReader.java
@@ -144,7 +144,7 @@ public class Log4jFileReader implements Loggable {
                 .filter(line -> line.contains(expectedStatus.title))
                 .findFirst()
                 .ifPresentOrElse(
-                        (value) -> log().info("Found status {}", expectedStatus.title),
+                        value -> log().info("Found status {}", expectedStatus.title),
                         () -> Assert.fail(String.format("'%s' should have status '%s'", methodNameSlug, expectedStatus))
                 );
     }

--- a/integration-tests/src/main/java/eu/tsystems/mms/tic/testframework/core/utils/Log4jFileReader.java
+++ b/integration-tests/src/main/java/eu/tsystems/mms/tic/testframework/core/utils/Log4jFileReader.java
@@ -140,13 +140,11 @@ public class Log4jFileReader implements Loggable {
         final List<String> foundEntries = filterLogForTestMethod(classNameSlug, methodNameSlug);
 
         log().debug("Asserting '{}' for '{}'", expectedStatus, methodNameSlug);
-        foundEntries.stream()
-                .filter(line -> line.contains(expectedStatus.title))
-                .findFirst()
-                .ifPresentOrElse(
-                        value -> log().info("Found status {}", expectedStatus.title),
-                        () -> Assert.fail(String.format("'%s' should have status '%s'", methodNameSlug, expectedStatus))
-                );
+        if (foundEntries.stream().anyMatch(line -> line.contains(expectedStatus.title))) {
+            log().info("Found status {}", expectedStatus.title);
+        } else {
+            Assert.fail(String.format("'%s' should have status '%s'", methodNameSlug, expectedStatus));
+        }
     }
 
     /**

--- a/integration-tests/src/test/java/io/testerra/test/pretest_status/DataProviderTest.java
+++ b/integration-tests/src/test/java/io/testerra/test/pretest_status/DataProviderTest.java
@@ -21,12 +21,14 @@
 
 package io.testerra.test.pretest_status;
 
+import eu.tsystems.mms.tic.testframework.testing.AssertProvider;
 import eu.tsystems.mms.tic.testframework.testing.TesterraTest;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
+import org.testng.annotations.Optional;
 import org.testng.annotations.Test;
 
-public class DataProviderTest extends TesterraTest {
+public class DataProviderTest extends TesterraTest implements AssertProvider {
 
     /**
      * This test uses an external data provider throwing an exception
@@ -59,6 +61,31 @@ public class DataProviderTest extends TesterraTest {
      */
     @Test(dataProvider = "dataProviderThrowingAssertion")
     public void testT03_AssertFailedDataProvider(String dp) throws Exception {
+    }
+
+    @DataProvider
+    public Object[][] dataProviderSimple() {
+        String[][] objects = {{"passed"}, {"failed"}};
+        return objects;
+    }
+
+    /**
+     * This tests uses a default dataprovider with 2 elements, 1 passed, 1 failed.
+     */
+    @Test(dataProvider = "dataProviderSimple")
+    public void testT04_DataProviderWithFailedTests(String dp) {
+        Assert.assertEquals(dp, "passed");
+    }
+
+    /**
+     * This tests uses a default dataprovider with 2 elements.
+     * Failed assertion is only optional (also passed)
+     */
+    @Test(dataProvider = "dataProviderSimple")
+    public void testT05_DataProviderWithFailedTestsOptional(String dp) {
+        CONTROL.optionalAssertions(() -> {
+            ASSERT.assertEquals(dp, "passed");
+        });
     }
 
 }

--- a/integration-tests/src/test/java/io/testerra/test/status/CheckTestStatusTest.java
+++ b/integration-tests/src/test/java/io/testerra/test/status/CheckTestStatusTest.java
@@ -53,7 +53,10 @@ public class CheckTestStatusTest extends TesterraTest {
                 {"test_validExpectedFailed_withMethod", Status.FAILED_EXPECTED},
                 {"test_invalidExpectedFailed_withMethod", Status.FAILED},
                 {"test_validExpectedFailed_withClass", Status.FAILED_EXPECTED},
-                {"test_invalidExpectedFailed_withClass", Status.FAILED}
+                {"test_invalidExpectedFailed_withClass", Status.FAILED},
+                {"testT04_DataProviderWithFailedTests", Status.FAILED},
+                {"testT04_DataProviderWithFailedTests", Status.PASSED},
+                {"testT05_DataProviderWithFailedTestsOptional", Status.PASSED}
         };
     }
 
@@ -95,13 +98,13 @@ public class CheckTestStatusTest extends TesterraTest {
                 {"*** Stats: SuiteContexts:  2", "SuiteContext"},
                 {"*** Stats: TestContexts:   2", "TestContext"},
                 {"*** Stats: ClassContexts:  5", "ClassContext"},
-                {"*** Stats: MethodContexts: 43", "MethodContexts"},
-                {"*** Stats: Test Methods Count: 40 (30 relevant)", "Test methods"},
-                {"*** Stats: Failed: 7", "Failed tests"},
+                {"*** Stats: MethodContexts: 47", "MethodContexts"},
+                {"*** Stats: Test Methods Count: 44 (34 relevant)", "Test methods"},
+                {"*** Stats: Failed: 8", "Failed tests"},
                 {"*** Stats: Retried: 10", "Retried tests"},
                 {"*** Stats: Expected Failed: 6", "Expected failed tests"},
                 {"*** Stats: Skipped: 5", "Skipped tests"},
-                {"*** Stats: Passed: 12 ⊃ Recovered: 4 ⊃ Repaired: 1", "Passed tests"}
+                {"*** Stats: Passed: 15 ⊃ Recovered: 4 ⊃ Repaired: 1", "Passed tests"}
         };
     }
 


### PR DESCRIPTION
# Description

In case of optional assertions a testmethod was set to status `SKIPPED` if the test was part of a dataprovider run.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
