### PR TITLE
Fix/link exclusive sessions to methodcontext

### DIFF
--- a/docs/src/docs/best-practices.adoc
+++ b/docs/src/docs/best-practices.adoc
@@ -2,6 +2,7 @@
 
 This section contains several articles for best practices for the usage and implementation of tests with Testerra.
 
+include::best-practices/webdriver-manager-bp.adoc[leveloffset=+1]
 include::best-practices/browser-specific-knowledge.adoc[leveloffset=+1]
 include::best-practices/html-elements.adoc[leveloffset=+1]
 include::best-practices/multiple-profiles.adoc[leveloffset=+1]

--- a/docs/src/docs/best-practices/webdriver-manager-bp.adoc
+++ b/docs/src/docs/best-practices/webdriver-manager-bp.adoc
@@ -1,0 +1,71 @@
+= Handling of WebDriver instances
+
+We strongly recommend the following rules for dealing with WebDriver instances:
+
+*Create or call your WebDriver instances only within the context of test or setup methods.*
+
+✅ Good practice
+[source, java]
+----
+@BeforeMethod
+public void before() {
+    // Context of a setup method
+    WebDriver driver = WebDriverManager.getWebDriver();
+}
+
+@Test
+public void myDemoTest() {
+    // Context of a test method
+    WebDriver driver = WEB_DRIVER_MANAGER.getWebDriver();
+    ...
+}
+----
+
+❌ Bad practice - don't do this
+[source, java]
+----
+public class MyTest extends TesterraTest
+        implements WebDriverManagerProvider, PageFactoryProvider {
+
+    // This may cause side effects!
+    // The session information are missing in the report because
+    // your new session cannot link to the method context
+    WebDriver driver = WEB_DRIVER_MANAGER.getWebDriver();
+
+    @Test
+    public void myDemoTest() {
+        StartPage startPage = PAGE_FACTORY.createPage(StartPage.class, driver);
+        ...
+    }
+}
+----
+
+*Only store the names of WebDriver instances, not the whole object.*
+
+✅ Good practice
+[source, java]
+----
+public class MyTest extends TesterraTest implements WebDriverManagerProvider {
+
+    private String exclusiveSessionId = "";
+    private String normalSesion = "mySession"
+
+    @BeforeClass
+    public void beforeClass() {
+        WebDriver driver1 = WEB_DRIVER_MANAGER.getWebDriver();
+        exclusiveSessionId = WEB_DRIVER_MANAGER.makeExclusive(driver1);
+
+        // Create a session with a custom name
+        WebDriver driver2 = WEB_DRIVER_MANAGER.getWebDriver(this.normalSesion);
+        ...
+    }
+
+    @Test
+    public void myDemoTest() {
+        // Always use the WEB_DRIVER_MANAGER
+        WebDriver driver1 = WEB_DRIVER_MANAGER.getWebDriver(this.exclusiveSessionId);
+        WebDriver driver2 = WEB_DRIVER_MANAGER.getWebDriver(this.normalSesion);
+        ...
+    }
+}
+----

--- a/docs/src/docs/utilities/testui-utilities.adoc
+++ b/docs/src/docs/utilities/testui-utilities.adoc
@@ -1,6 +1,4 @@
-= UITest Utilities (*deprecated*)
-
-NOTE: This class is marked as `@deprecated` and should not be used anymore.
+= UITest Utilities
 
 The `UITestUtils` supports you to generate additional screenshots.
 
@@ -24,6 +22,20 @@ class ExamplePage extends Page {
     }
 }
 ----
+
+.Take screenshots of all WebDriver instances of current test.
+[source, java]
+----
+@Test
+public void testDemo() {
+    WEB_DRIVER_MANAGER.getWebDriver("session1");
+    WEB_DRIVER_MANAGER.getWebDriver("session2");
+    // Screenshots from 'session1' and 'session2' are created
+    UITestUtils.takeScreenshots();
+}
+----
+
+NOTE: `UITestUtils.takeScreenshots()` takes only screenshot from WebDriver instances you have used in your current test.
 
 You can also store a simple screenshot to your project directory.
 

--- a/docs/src/docs/webdrivermanager/webdrivermanager-sessions.adoc
+++ b/docs/src/docs/webdrivermanager/webdrivermanager-sessions.adoc
@@ -84,6 +84,8 @@ For every other call of `getWebDriver()` in the *same test context* WebDriverMan
 
 This makes it possible to retrieve the current session in any context and avoids to force the user to pass the instance around.
 
+IMPORTANT: Please have a look to <<_handling_of_webdriver_instances, best practices of dealing with WebDriver instances>>
+
 == WebDriver lifecycle
 
 The default behaviour of Testerra's `WebDriverManager` is, to create unique WebDrivers for each thread and/or test method.
@@ -137,7 +139,7 @@ WEB_DRIVER_MANAGER.shutdownAllSessions()
 [NOTE]
 ====
 Please do not use Selenium provided methods to close `WebDriver` sessions.
-Have a further read in our known issue section: <<Closing `WebDriver` sessions without using Testerra `WebDriverManager`>>.
+Have a further read in our known issue section: <<Close WebDriver sessions without WebDriverManager>>.
 ====
 
 == Shared sessions in one thread

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/execution/worker/finish/TakeInSessionEvidencesWorker.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/execution/worker/finish/TakeInSessionEvidencesWorker.java
@@ -48,6 +48,9 @@ public class TakeInSessionEvidencesWorker implements MethodEndEvent.Listener {
     @Override
     @Subscribe
     public void onMethodEnd(MethodEndEvent methodEndEvent) {
+        /*
+         * Take Screenshot of failure and log it into report.
+         */
         if (methodEndEvent.isFailed()) {
             collect(methodEndEvent);
         } else if (methodEndEvent.isSkipped()) {

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/execution/worker/finish/WebDriverShutDownWorker.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/execution/worker/finish/WebDriverShutDownWorker.java
@@ -33,10 +33,6 @@ public class WebDriverShutDownWorker implements MethodEndEvent.Listener, WebDriv
     @Subscribe
     public void onMethodEnd(MethodEndEvent methodEndEvent) {
         ITestResult iTestResult = methodEndEvent.getTestResult();
-
-        /*
-         * Take Screenshot of failure and log it into report.
-         */
         if (iTestResult != null) {
             methodEndEvent.getMethodContext().readSessionContexts().forEach(sessionContext -> {
                 WebDriverRequest webDriverRequest = sessionContext.getWebDriverRequest();

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/execution/worker/finish/WebDriverShutDownWorker.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/execution/worker/finish/WebDriverShutDownWorker.java
@@ -42,8 +42,8 @@ public class WebDriverShutDownWorker implements MethodEndEvent.Listener, WebDriv
                 WebDriverRequest webDriverRequest = sessionContext.getWebDriverRequest();
                 boolean shouldClose = false;
                 /**
-                 * Shutting down sessions when the method is ONLY a test is @deprecated.
-                 * Testerra is going to shutdown ALL sessions after method in the future.
+                 * Shutting down sessions when the method is ONLY a test.
+                 * Testerra does not shutdown sessions after configuration methods.
                  */
                 if (iTestResult.getMethod().isTest() && webDriverRequest.getShutdownAfterTest()) {
                     shouldClose = true;

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/utils/UITestUtils.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/utils/UITestUtils.java
@@ -318,16 +318,15 @@ public class UITestUtils implements WebDriverManagerProvider {
         Optional<MethodContext> optionalMethodContext = executionContextController.getCurrentMethodContext();
 
         // Find exclusive sessions linked to current method context
-        List<String> exclusiveSessionKeys = new ArrayList<>();
+        Stream<String> exclusiveSessionKeys = Stream.empty();
         if (optionalMethodContext.isPresent()) {
             exclusiveSessionKeys = optionalMethodContext.get().readSessionContexts()
                     .map(SessionContext::getSessionKey)
-                    .filter(sessionKey -> sessionKey.startsWith(SessionContext.EXCLUSIVE_PREFIX))
-                    .collect(Collectors.toList());
+                    .filter(sessionKey -> sessionKey.startsWith(SessionContext.EXCLUSIVE_PREFIX));
         }
 
         // Take all normal webdriver and linked exclusive webdriver and create screenshots
-        Stream<Screenshot> screenshotStream = Stream.concat(WEB_DRIVER_MANAGER.readWebDriversFromCurrentThread(), exclusiveSessionKeys.stream().map(WEB_DRIVER_MANAGER::getWebDriver))
+        Stream<Screenshot> screenshotStream = Stream.concat(WEB_DRIVER_MANAGER.readWebDriversFromCurrentThread(), exclusiveSessionKeys.map(WEB_DRIVER_MANAGER::getWebDriver))
                 .map(UITestUtils::pTakeAllScreenshotsForSession)
                 .flatMap(Collection::stream);
 

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/utils/UITestUtils.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/utils/UITestUtils.java
@@ -308,7 +308,8 @@ public class UITestUtils implements WebDriverManagerProvider {
     }
 
     /**
-     * Make screenshots from all open browser windows/selenium, webdriver instances.
+     * Make screenshots from all open browser windows/selenium, webdriver instances of the current thread
+     * and of exclusive webdriver instances of the current method context (if exists).
      *
      * @param publishToReport True for publish directly into report.
      * @return ScreenshotPaths.

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/WebDriverSessionsManager.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/WebDriverSessionsManager.java
@@ -338,20 +338,21 @@ public final class WebDriverSessionsManager {
 
     public static EventFiringWebDriver getWebDriver(final WebDriverRequest webDriverRequest) {
         String sessionKey = webDriverRequest.getSessionKey();
+        EventFiringWebDriver existingWebDriver = null;
         /*
         Check for exclusive session
          */
         if (sessionKey.startsWith(SessionContext.EXCLUSIVE_PREFIX)) {
             // returning exclusive session
             if (EXCLUSIVE_SESSION_KEY_WEBDRIVER_MAP.containsKey(sessionKey)) {
-                return EXCLUSIVE_SESSION_KEY_WEBDRIVER_MAP.get(sessionKey);
+                existingWebDriver = EXCLUSIVE_SESSION_KEY_WEBDRIVER_MAP.get(sessionKey);
             } else {
                 throw new SystemException("No Session for key: " + sessionKey);
             }
+        } else {
+            String fullSessionKey = getThreadSessionKey(sessionKey);
+            existingWebDriver = THREAD_SESSION_KEY_WEBDRIVER_MAP.get(fullSessionKey);
         }
-
-        String fullSessionKey = getThreadSessionKey(sessionKey);
-        EventFiringWebDriver existingWebDriver = THREAD_SESSION_KEY_WEBDRIVER_MAP.get(fullSessionKey);
 
         /*
         session already exists?
@@ -359,13 +360,26 @@ public final class WebDriverSessionsManager {
         if (existingWebDriver != null) {
             /*
             Link sessionContext to methodContext if not exist
-             e.g. Session was created in setup method and reused in test method
+            e.g. Session was created in setup method and reused in test method or exclusive session is used in current test.
             */
-            executionContextController.getCurrentSessionContext().ifPresent(currentSessionContext ->
-                    executionContextController.getCurrentMethodContext().ifPresent(currentMethodContext ->
-                            currentMethodContext.addSessionContext(currentSessionContext)
-                    ));
+            if(sessionKey.startsWith(SessionContext.EXCLUSIVE_PREFIX)) {
+                // Link an exclusive sessionContext
+                executionContextController.getExecutionContext().readExclusiveSessionContexts()
+                        .filter(sessionContext -> sessionContext.getSessionKey().equals(sessionKey))
+                        .findFirst()
+                        .ifPresent(sessionContext ->
+                                executionContextController.getCurrentMethodContext().ifPresent(currentMethodContext ->
+                                        currentMethodContext.addSessionContext(sessionContext)
+                                ));
 
+
+            } else {
+                // Link an normal sessionContext
+                executionContextController.getCurrentSessionContext().ifPresent(currentSessionContext ->
+                        executionContextController.getCurrentMethodContext().ifPresent(currentMethodContext ->
+                                currentMethodContext.addSessionContext(currentSessionContext)
+                        ));
+            }
             return existingWebDriver;
         }
 

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/WebDriverSessionsManager.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/WebDriverSessionsManager.java
@@ -309,6 +309,7 @@ public final class WebDriverSessionsManager {
          */
         sessionContext.setSessionKey(exclusiveSessionKey);
         sessionContext.getWebDriverRequest().setShutdownAfterTest(false);
+        sessionContext.getWebDriverRequest().setShutdownAfterTestFailed(false);
         executionContextController.getExecutionContext().addExclusiveSessionContext(sessionContext);
         Testerra.getEventBus().post(new ContextUpdateEvent().setContext(sessionContext));
 
@@ -371,8 +372,6 @@ public final class WebDriverSessionsManager {
                                 executionContextController.getCurrentMethodContext().ifPresent(currentMethodContext ->
                                         currentMethodContext.addSessionContext(sessionContext)
                                 ));
-
-
             } else {
                 // Link an normal sessionContext
                 executionContextController.getCurrentSessionContext().ifPresent(currentSessionContext ->

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/WebDriverSessionsManager.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/WebDriverSessionsManager.java
@@ -193,6 +193,7 @@ public final class WebDriverSessionsManager {
         // store to method context
         executionContextController.getCurrentMethodContext().ifPresent(methodContext -> {
             methodContext.addSessionContext(sessionContext);
+            executionContextController.setCurrentSessionContext(sessionContext);
         });
         storeWebDriverSession(eventFiringWebDriver, sessionContext);
     }

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/WebDriverSessionsManager.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/WebDriverSessionsManager.java
@@ -374,7 +374,7 @@ public final class WebDriverSessionsManager {
                                         currentMethodContext.addSessionContext(sessionContext)
                                 ));
             } else {
-                // Link an normal sessionContext
+                // Link a normal sessionContext
                 executionContextController.getCurrentSessionContext().ifPresent(currentSessionContext ->
                         executionContextController.getCurrentMethodContext().ifPresent(currentMethodContext ->
                                 currentMethodContext.addSessionContext(currentSessionContext)

--- a/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/playground/ExclusiveSession1.java
+++ b/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/playground/ExclusiveSession1.java
@@ -1,0 +1,40 @@
+package eu.tsystems.mms.tic.testframework.playground;
+
+import eu.tsystems.mms.tic.testframework.AbstractTestSitesTest;
+import eu.tsystems.mms.tic.testframework.testing.PageFactoryProvider;
+import eu.tsystems.mms.tic.testframework.utils.TimerUtils;
+import eu.tsystems.mms.tic.testframework.utils.UITestUtils;
+import org.openqa.selenium.WebDriver;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * Created on 19.07.2022
+ *
+ * @author mgn
+ */
+public class ExclusiveSession1 extends AbstractTestSitesTest implements PageFactoryProvider {
+
+    private String exclusiveSessionId = "";
+
+    @BeforeClass
+    public void beforeClass() {
+        WebDriver driver = getWebDriver();
+        exclusiveSessionId = WEB_DRIVER_MANAGER.makeExclusive(driver);
+    }
+
+    @Test
+    public void testT01SessionTest() {
+        WEB_DRIVER_MANAGER.getWebDriver(exclusiveSessionId);
+        TimerUtils.sleep(2_000, "Extend test duration");
+        UITestUtils.takeScreenshots();
+        TimerUtils.sleep(5_000, "Extend test duration");
+    }
+
+    @AfterClass
+    public void afterClass() {
+        WEB_DRIVER_MANAGER.shutdownSession(exclusiveSessionId);
+    }
+
+}

--- a/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/playground/ExclusiveSession1.java
+++ b/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/playground/ExclusiveSession1.java
@@ -10,7 +10,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /**
- * Created on 19.07.2022
  *
  * @author mgn
  */

--- a/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/playground/ExclusiveSession2.java
+++ b/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/playground/ExclusiveSession2.java
@@ -9,8 +9,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-/**
- * Created on 19.07.2022
+/*
  *
  * @author mgn
  */

--- a/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/playground/ExclusiveSession2.java
+++ b/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/playground/ExclusiveSession2.java
@@ -1,0 +1,42 @@
+package eu.tsystems.mms.tic.testframework.playground;
+
+import eu.tsystems.mms.tic.testframework.AbstractTestSitesTest;
+import eu.tsystems.mms.tic.testframework.core.pageobjects.testdata.PageWithNotExistingElement;
+import eu.tsystems.mms.tic.testframework.core.testpage.TestPage;
+import eu.tsystems.mms.tic.testframework.testing.PageFactoryProvider;
+import org.openqa.selenium.WebDriver;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * Created on 19.07.2022
+ *
+ * @author mgn
+ */
+public class ExclusiveSession2 extends AbstractTestSitesTest implements PageFactoryProvider {
+
+    private String exclusiveSessionId = "";
+
+    protected TestPage getTestPage() {
+        return TestPage.LAYOUT;
+    }
+
+    @BeforeClass
+    public void beforeClass() {
+        WebDriver driver = getWebDriver();
+        exclusiveSessionId = WEB_DRIVER_MANAGER.makeExclusive(driver);
+    }
+
+    @Test
+    public void testT02SessionTest() {
+        WebDriver driver = WEB_DRIVER_MANAGER.getWebDriver(exclusiveSessionId);
+        PAGE_FACTORY.createPage(PageWithNotExistingElement.class, driver);
+    }
+
+    @AfterClass
+    public void afterClass() {
+        WEB_DRIVER_MANAGER.shutdownSession(exclusiveSessionId);
+    }
+
+}

--- a/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/webdrivermanager/WebDriverManagerTest.java
+++ b/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/webdrivermanager/WebDriverManagerTest.java
@@ -93,13 +93,13 @@ public class WebDriverManagerTest extends TesterraTest implements WebDriverManag
         final WebDriver driver = new ChromeDriver(chromeOptions);
 
         // assert that webdrivermanager does not know about this session.
-        Assert.assertEquals(WebDriverSessionsManager.getWebDriversFromCurrentThread().count(), 0, "WebDriver Session should not active in this thread.");
+        Assert.assertEquals(WebDriverSessionsManager.getWebDriversFromCurrentThread().count(), 0, "No WebDriver sessions should active in this thread.");
         Assert.assertTrue(executionContextController.getCurrentSessionContext().isEmpty(), "The current session context should empty");
         // introduce it.
         WebDriverManager.introduceWebDriver(driver);
 
         // assert that webdrivermanager does know about the session.
-        Assert.assertEquals(WebDriverSessionsManager.getWebDriversFromCurrentThread().count(), 1, "WebDriver Session should active in this thread.");
+        Assert.assertEquals(WebDriverSessionsManager.getWebDriversFromCurrentThread().count(), 1, "One WebDriver session should active in this thread.");
         Assert.assertTrue(executionContextController.getCurrentSessionContext().isPresent(), "There should exist a current session context.");
     }
 
@@ -110,7 +110,7 @@ public class WebDriverManagerTest extends TesterraTest implements WebDriverManag
 
         String sessionId = WEB_DRIVER_MANAGER.makeExclusive(exclusiveDriver);
 
-        Assert.assertTrue(executionContextController.getCurrentSessionContext().isEmpty(), "The current session context should empty");
+        Assert.assertTrue(executionContextController.getCurrentSessionContext().isEmpty(), "The current session context should be empty.");
 
         Assert.assertNotNull(WebDriverSessionsManager.getSessionContext(exclusiveDriver).get());
 
@@ -135,12 +135,12 @@ public class WebDriverManagerTest extends TesterraTest implements WebDriverManag
 
         WEB_DRIVER_MANAGER.getWebDriver(t03aSessionId);
 
-        Assert.assertEquals(this.readSessionContextFromMethodContext().count(), 1, "A session should link to current method context");
-        this.readSessionContextFromMethodContext()
-                .filter(sessionContext -> sessionContext.getSessionKey().equals(t03aSessionId))
-                .findAny()
-                .ifPresentOrElse(sessionContext -> Assert.assertTrue(true),
-                        () -> Assert.fail("Exclusive session not found in current method context"));
+        Assert.assertEquals(this.readSessionContextFromMethodContext().count(), 1, "One session should link to current method context");
+        if (this.readSessionContextFromMethodContext()
+                .map(SessionContext::getSessionKey)
+                .noneMatch(t03aSessionId::equals)) {
+            Assert.fail("Exclusive session not found in current method context");
+        }
     }
 
     @Test
@@ -328,7 +328,7 @@ public class WebDriverManagerTest extends TesterraTest implements WebDriverManag
 
         // Create a second session 'default'
         WEB_DRIVER_MANAGER.getWebDriver();
-        Assert.assertEquals(this.readSessionContextFromMethodContext().count(), 2, "Current method context should 2 sessions.");
+        Assert.assertEquals(this.readSessionContextFromMethodContext().count(), 2, "Current method context should have 2 sessions.");
 
         WEB_DRIVER_MANAGER.shutdownAllThreadSessions();
     }

--- a/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/webdrivermanager/WebDriverManagerTest.java
+++ b/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/webdrivermanager/WebDriverManagerTest.java
@@ -22,10 +22,13 @@
 package eu.tsystems.mms.tic.testframework.test.webdrivermanager;
 
 import eu.tsystems.mms.tic.testframework.common.PropertyManagerProvider;
+import eu.tsystems.mms.tic.testframework.common.Testerra;
 import eu.tsystems.mms.tic.testframework.constants.Browsers;
 import eu.tsystems.mms.tic.testframework.report.model.context.SessionContext;
 import eu.tsystems.mms.tic.testframework.report.utils.DefaultExecutionContextController;
+import eu.tsystems.mms.tic.testframework.report.utils.IExecutionContextController;
 import eu.tsystems.mms.tic.testframework.testing.TesterraTest;
+import eu.tsystems.mms.tic.testframework.testing.WebDriverManagerProvider;
 import eu.tsystems.mms.tic.testframework.utils.CertUtils;
 import eu.tsystems.mms.tic.testframework.webdrivermanager.DesktopWebDriverRequest;
 import eu.tsystems.mms.tic.testframework.webdrivermanager.IWebDriverManager;
@@ -45,6 +48,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 /**
  * Tests for WebDriverManager
@@ -54,12 +58,14 @@ import java.util.regex.Pattern;
  *
  * @author Eric Kubenka
  */
-public class WebDriverManagerTest extends TesterraTest implements PropertyManagerProvider {
+public class WebDriverManagerTest extends TesterraTest implements WebDriverManagerProvider, PropertyManagerProvider {
+
+    private IExecutionContextController executionContextController = Testerra.getInjector().getInstance(IExecutionContextController.class);
 
     @Test
     public void testT01_isJavaScriptActivated() {
 
-        final WebDriver webDriver = WebDriverManager.getWebDriver();
+        final WebDriver webDriver = WEB_DRIVER_MANAGER.getWebDriver();
         final boolean javaScriptActivated = WebDriverManager.isJavaScriptActivated(webDriver);
 
         Assert.assertTrue(javaScriptActivated, "JavaScript activated by default.");
@@ -87,31 +93,54 @@ public class WebDriverManagerTest extends TesterraTest implements PropertyManage
         final WebDriver driver = new ChromeDriver(chromeOptions);
 
         // assert that webdrivermanager does not know about this session.
-        Assert.assertFalse(WebDriverManager.hasSessionsActiveInThisThread(), "WebDriver Session active in this thread.");
-
+        Assert.assertEquals(WebDriverSessionsManager.getWebDriversFromCurrentThread().count(), 0, "WebDriver Session should not active in this thread.");
+        Assert.assertTrue(executionContextController.getCurrentSessionContext().isEmpty(), "The current session context should empty");
         // introduce it.
         WebDriverManager.introduceWebDriver(driver);
 
         // assert that webdrivermanager does know about the session.
-        Assert.assertTrue(WebDriverManager.hasSessionsActiveInThisThread(), "WebDriver Session active in this thread.");
+        Assert.assertEquals(WebDriverSessionsManager.getWebDriversFromCurrentThread().count(), 1, "WebDriver Session should active in this thread.");
+        Assert.assertTrue(executionContextController.getCurrentSessionContext().isPresent(), "There should exist a current session context.");
     }
 
     @Test
     public void testT03_MakeSessionExclusive() {
-        WebDriver exclusiveDriver = WebDriverManager.getWebDriver();
-        Assert.assertEquals(WebDriverSessionsManager.getWebDriversFromCurrentThread().count(), 1);
+        WebDriver exclusiveDriver = WEB_DRIVER_MANAGER.getWebDriver();
+        Assert.assertTrue(executionContextController.getCurrentSessionContext().isPresent(), "There should exist a current session context.");
 
-        String sessionId = WebDriverManager.makeSessionExclusive(exclusiveDriver);
+        String sessionId = WEB_DRIVER_MANAGER.makeExclusive(exclusiveDriver);
 
-        Assert.assertEquals(WebDriverSessionsManager.getWebDriversFromCurrentThread().count(), 0);
+        Assert.assertTrue(executionContextController.getCurrentSessionContext().isEmpty(), "The current session context should empty");
 
         Assert.assertNotNull(WebDriverSessionsManager.getSessionContext(exclusiveDriver).get());
 
-        WebDriver driver2 = WebDriverManager.getWebDriver("Session2");
-        WebDriver exclusiveDriverActual = WebDriverManager.getWebDriver(sessionId);
+        WebDriver driver2 = WEB_DRIVER_MANAGER.getWebDriver("Session2");
+        WebDriver exclusiveDriverActual = WEB_DRIVER_MANAGER.getWebDriver(sessionId);
 
         Assert.assertEquals(exclusiveDriver, exclusiveDriverActual, "Got the same WebDriver!");
-        WebDriverManager.shutdownExclusiveSession(sessionId);
+        WEB_DRIVER_MANAGER.shutdownSession(sessionId);
+    }
+
+    private String t03aSessionId = "";
+
+    @Test
+    public void testT03a_SessionExclusivePrepareTest() {
+        WebDriver exclusiveDriver = WEB_DRIVER_MANAGER.getWebDriver();
+        t03aSessionId = WEB_DRIVER_MANAGER.makeExclusive(exclusiveDriver);
+    }
+
+    @Test(dependsOnMethods = "testT03a_SessionExclusivePrepareTest")
+    public void testT03b_SessionExclusiveCheckLinkedSession() {
+        Assert.assertEquals(this.readSessionContextFromMethodContext().count(), 0, "No session should link to current method context");
+
+        WEB_DRIVER_MANAGER.getWebDriver(t03aSessionId);
+
+        Assert.assertEquals(this.readSessionContextFromMethodContext().count(), 1, "A session should link to current method context");
+        this.readSessionContextFromMethodContext()
+                .filter(sessionContext -> sessionContext.getSessionKey().equals(t03aSessionId))
+                .findAny()
+                .ifPresentOrElse(sessionContext -> Assert.assertTrue(true),
+                        () -> Assert.fail("Exclusive session not found in current method context"));
     }
 
     @Test
@@ -189,7 +218,7 @@ public class WebDriverManagerTest extends TesterraTest implements PropertyManage
         Dimension expected = new Dimension(1024, 768);
         DesktopWebDriverRequest request = new DesktopWebDriverRequest();
         request.setWindowSize(expected);
-        WebDriver webDriver = WebDriverManager.getWebDriver(request);
+        WebDriver webDriver = WEB_DRIVER_MANAGER.getWebDriver(request);
         Dimension size = webDriver.manage().window().getSize();
         Assert.assertEquals(size.getWidth(), expected.getWidth());
         Assert.assertEquals(size.getHeight(), expected.getHeight());
@@ -198,7 +227,7 @@ public class WebDriverManagerTest extends TesterraTest implements PropertyManage
     @Test
     public void testT08_invalidWindowSize() {
         PROPERTY_MANAGER.setTestLocalProperty(DesktopWebDriverRequest.Properties.WINDOW_SIZE, "katze");
-        String property = PROPERTY_MANAGER.getProperty(DesktopWebDriverRequest.Properties.WINDOW_SIZE, PROPERTY_MANAGER.getProperty(DesktopWebDriverRequest.Properties.DISPLAY_RESOLUTION));
+        String property = PROPERTY_MANAGER.getProperty(DesktopWebDriverRequest.Properties.WINDOW_SIZE, PROPERTY_MANAGER.getProperty(DesktopWebDriverRequest.Properties.WINDOW_SIZE));
         Assert.assertEquals(property, "katze");
 
         assertNewWebDriverWindowSize(this.getDefaultDimension());
@@ -237,11 +266,11 @@ public class WebDriverManagerTest extends TesterraTest implements PropertyManage
         Assert.assertEquals(windowSize.getWidth(), expected.getWidth());
         Assert.assertEquals(windowSize.getHeight(), expected.getHeight());
 
-        WebDriver webDriver = WebDriverManager.getWebDriver(request);
+        WebDriver webDriver = WEB_DRIVER_MANAGER.getWebDriver(request);
         Dimension size = webDriver.manage().window().getSize();
         Assert.assertEquals(size.getWidth(), expected.getWidth());
         Assert.assertEquals(size.getHeight(), expected.getHeight());
-        WebDriverManager.shutdown();
+        WEB_DRIVER_MANAGER.shutdownAllThreadSessions();
     }
 
     @Test
@@ -252,7 +281,7 @@ public class WebDriverManagerTest extends TesterraTest implements PropertyManage
 
         DesktopWebDriverRequest request = new DesktopWebDriverRequest();
 
-        WebDriverManager.getWebDriver(request);
+        WEB_DRIVER_MANAGER.getWebDriver(request);
 
         Assert.assertTrue(request.getDesiredCapabilities().acceptInsecureCerts());
     }
@@ -264,7 +293,7 @@ public class WebDriverManagerTest extends TesterraTest implements PropertyManage
 
         Assert.assertNotEquals(defaultLocale, sessionLocale);
 
-        WebDriver webDriver = WebDriverManager.getWebDriver();
+        WebDriver webDriver = WEB_DRIVER_MANAGER.getWebDriver();
         Assert.assertTrue(WebDriverManager.setSessionLocale(webDriver, sessionLocale));
 
         Assert.assertEquals(WebDriverManager.getSessionLocale(webDriver).orElse(null), sessionLocale);
@@ -278,29 +307,33 @@ public class WebDriverManagerTest extends TesterraTest implements PropertyManage
         DesktopWebDriverRequest desktopWebDriverRequest = new DesktopWebDriverRequest();
         desktopWebDriverRequest.setShutdownAfterTest(false);
         desktopWebDriverRequest.setSessionKey(sessionKey);
-        WebDriverManager.getWebDriver(desktopWebDriverRequest);
+        WEB_DRIVER_MANAGER.getWebDriver(desktopWebDriverRequest);
         new DefaultExecutionContextController().getCurrentSessionContext().ifPresent(sessionContext -> reusedSessionId = sessionContext.getRemoteSessionId().get());
     }
 
     @Test(dependsOnMethods = "testT12_ReuseSession1")
     public void testT13_ResuseSession2() {
         DefaultExecutionContextController executionContextController = new DefaultExecutionContextController();
-        WebDriverManager.getWebDriver(sessionKey);
+        WEB_DRIVER_MANAGER.getWebDriver(sessionKey);
 
         Assert.assertEquals(this.reusedSessionId, executionContextController.getCurrentSessionContext().get().getRemoteSessionId().get());
-        Optional<SessionContext> foundSessionContext = executionContextController.getCurrentMethodContext().get().readSessionContexts().filter(
+        Optional<SessionContext> foundSessionContext = this.readSessionContextFromMethodContext().filter(
                 sessionContext -> sessionContext.getSessionKey().equals(sessionKey)).findFirst();
         Assert.assertTrue(foundSessionContext.isPresent(), "Method context should contain the reused session context");
         Assert.assertEquals(reusedSessionId, foundSessionContext.get().getRemoteSessionId().get(),
                 "Session ID of session context should the same of session context of method `testT12_ReuseSession1`");
 
         // Second access to 'reuse' session has no impact on methodContext
-        WebDriverManager.getWebDriver(sessionKey);
+        WEB_DRIVER_MANAGER.getWebDriver(sessionKey);
 
         // Create a second session 'default'
-        WebDriverManager.getWebDriver();
-        Assert.assertEquals(executionContextController.getCurrentMethodContext().get().readSessionContexts().count(), 2, "Current method context should 2 sessions.");
+        WEB_DRIVER_MANAGER.getWebDriver();
+        Assert.assertEquals(this.readSessionContextFromMethodContext().count(), 2, "Current method context should 2 sessions.");
 
-        WebDriverManager.shutdown();
+        WEB_DRIVER_MANAGER.shutdownAllThreadSessions();
+    }
+
+    private Stream<SessionContext> readSessionContextFromMethodContext() {
+        return executionContextController.getCurrentMethodContext().get().readSessionContexts();
     }
 }

--- a/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/webdrivermanager/WebDriverManagerTest.java
+++ b/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/webdrivermanager/WebDriverManagerTest.java
@@ -227,7 +227,7 @@ public class WebDriverManagerTest extends TesterraTest implements WebDriverManag
     @Test
     public void testT08_invalidWindowSize() {
         PROPERTY_MANAGER.setTestLocalProperty(DesktopWebDriverRequest.Properties.WINDOW_SIZE, "katze");
-        String property = PROPERTY_MANAGER.getProperty(DesktopWebDriverRequest.Properties.WINDOW_SIZE, PROPERTY_MANAGER.getProperty(DesktopWebDriverRequest.Properties.WINDOW_SIZE));
+        String property = PROPERTY_MANAGER.getProperty(DesktopWebDriverRequest.Properties.WINDOW_SIZE);
         Assert.assertEquals(property, "katze");
 
         assertNewWebDriverWindowSize(this.getDefaultDimension());


### PR DESCRIPTION
# Description

In case of failed tests the `UiTestUtils.takeScreenshots()` is called to create screenshots of all webdriver in current thread and of all existing exclusive sessions.

In case of using more exclusive sessions in parallel a failed test method could get screenshots from sessions which are never used in current test method. 

This PR changes this behaviour as follows:
* Exclusive sessions are linked now to current method context only if used!
* Before creating screenshots the `UiTestUtils.takeScreenshots()` checks the linked exclusive sessions. All other exclusive sessions are ignored.
  Keep in mind that `takeScreenshots()` still takes  screenshots from all _normal_ webdriver sessions from current thread (here is no filtering).

Ho it looks in the report:
* Before change method steps contains screenshots of all existing exclusive sessions:
  ![image](https://user-images.githubusercontent.com/22025965/179802201-c3890c21-e96c-403d-a2ab-8f849daf107c.png)
* After change method steps only contains screenshots of sessions belongs to test:
  ![image](https://user-images.githubusercontent.com/22025965/179802476-4a14c3c1-f5e0-491f-8b4b-d2d594acb4bb.png)

Note: Unit tests for this are planned in ReportNG tests.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
