### PR TITLE
Added collected checks for UiElements in pages

### DIFF
--- a/docs/src/docs/execution/test-controller.adoc
+++ b/docs/src/docs/execution/test-controller.adoc
@@ -5,7 +5,7 @@ The `TestControllerProvider` interface provides the `TestController` instance `C
 
 == Collected assertions
 
-Collecting assertion means, that a failing assertion will not abort the test method, but it will throw an exception at *the end* of the test method. So you have a chance to validate many more aspects in one test run.
+Collecting assertion means, that a failing assertion will not abort the test method, but it will throw an assertion error at *the end* of the test method. So you have a chance to validate many more aspects in one test run.
 
 [source,java]
 ----

--- a/docs/src/docs/pageobject/pageobjects-check-annotations.adoc
+++ b/docs/src/docs/pageobject/pageobjects-check-annotations.adoc
@@ -44,13 +44,25 @@ Available CheckRules are
 The default is IS_DISPLAYED.
 
 With the `optional` attribute, the check only adds an optional assertion to the report.
-The test will not be interrupted at this position.
+The test will not be interrupted at this position. See <<#_optional_assertions, Optional assertions>> for more details.
 
 [source,java]
 ----
 @Check(optional = true)
 private UiElement uiElement;
 ----
+
+With the `collect` attribute you can collect all checks. The test will not be interrupted, but if failes at the end. See <<#_collected_assertions, Collected assertions>> for more details.
+
+
+[source,java]
+----
+@Check(collect = true)
+private UiElement uiElement;
+----
+
+NOTE: It does not make sense to set `optional` and `collect` at the same UiElement! +
+Because `optional` is also a kind of `collect`, the `collect` attribute will be ignored.
 
 You can also define a special error message with the `prioritizedErrorMessage` attribute.
 

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/Check.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/Check.java
@@ -58,6 +58,6 @@ public @interface Check {
     /**
      * Collect assertions
      */
-    boolean collected() default false;
+    boolean collect() default false;
 
 }

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/Check.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/Check.java
@@ -55,4 +55,9 @@ public @interface Check {
 
     String prioritizedErrorMessage() default "";
 
+    /**
+     * Collect assertions
+     */
+    boolean collected() default false;
+
 }

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/internal/action/GuiElementCheckFieldAction.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/internal/action/GuiElementCheckFieldAction.java
@@ -60,7 +60,7 @@ public class GuiElementCheckFieldAction extends AbstractCheckFieldAction {
             }
         }
 
-        // Handling custom timetouts
+        // Handling custom timeouts
         int useTimeout;
         if (overrides.hasTimeout()) {
             useTimeout = overrides.getTimeoutInSeconds();
@@ -78,27 +78,27 @@ public class GuiElementCheckFieldAction extends AbstractCheckFieldAction {
             prevTimeout = overrides.setTimeout(useTimeout);
         }
 
-        /**
+        /*
          * It does not make sense to set both flags optional and collect!
          *
          * Because an optional assertion is always collected but without PageFactoryException
          * the 'optional' is prioritised over 'collected'.
          * In that case 'collected' will be ignored.
          */
-
-        // Handling collected assertions
-        Assertion previousAssertionImpl = null;
-        if (check.collect() && !check.optional()) {
-            CollectedAssertion assertionImpl = Testerra.getInjector().getInstance(CollectedAssertion.class);
-            previousAssertionImpl = overrides.setAssertionImpl(assertionImpl);
+        if (check.collect() && check.optional()) {
+            log().warn("{} -> {}: @Check 'collect' and 'optional' are used but 'collect' will be ignored."
+                    , this.declaringPage.getName(false), this.field.getName());
         }
 
-        // Handling optional assertions
+        // Handling optional and collected assertions
+        Assertion previousAssertionImpl = null;
         if (check.optional()) {
             OptionalAssertion assertionImpl = Testerra.getInjector().getInstance(OptionalAssertion.class);
             previousAssertionImpl = overrides.setAssertionImpl(assertionImpl);
+        } else if (check.collect()) {
+            CollectedAssertion assertionImpl = Testerra.getInjector().getInstance(CollectedAssertion.class);
+            previousAssertionImpl = overrides.setAssertionImpl(assertionImpl);
         }
-
 
         // Execute UiElement check
         switch (checkRule) {

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/internal/action/GuiElementCheckFieldAction.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/internal/action/GuiElementCheckFieldAction.java
@@ -23,6 +23,8 @@ package eu.tsystems.mms.tic.testframework.pageobjects.internal.action;
 import eu.tsystems.mms.tic.testframework.annotations.PageOptions;
 import eu.tsystems.mms.tic.testframework.common.Testerra;
 import eu.tsystems.mms.tic.testframework.enums.CheckRule;
+import eu.tsystems.mms.tic.testframework.execution.testng.Assertion;
+import eu.tsystems.mms.tic.testframework.execution.testng.OptionalAssertion;
 import eu.tsystems.mms.tic.testframework.pageobjects.Check;
 import eu.tsystems.mms.tic.testframework.pageobjects.GuiElement;
 import eu.tsystems.mms.tic.testframework.pageobjects.internal.AbstractPage;
@@ -57,8 +59,8 @@ public class GuiElementCheckFieldAction extends AbstractCheckFieldAction {
             }
         }
 
+        // Handling custom timetouts
         int useTimeout;
-
         if (overrides.hasTimeout()) {
             useTimeout = overrides.getTimeoutInSeconds();
         } else {
@@ -70,13 +72,19 @@ public class GuiElementCheckFieldAction extends AbstractCheckFieldAction {
                 }
             }
         }
-
         int prevTimeout = -1;
-
         if (useTimeout >= 0) {
             prevTimeout = overrides.setTimeout(useTimeout);
         }
 
+        // Handling optional
+        Assertion previousAssertionImpl = null;
+        if (check.optional()) {
+            OptionalAssertion assertionImpl = Testerra.getInjector().getInstance(OptionalAssertion.class);
+            previousAssertionImpl = overrides.setAssertionImpl(assertionImpl);
+        }
+
+        // Execute UiElement check
         switch (checkRule) {
             case IS_PRESENT:
                 guiElement.expect().present(true);
@@ -99,6 +107,9 @@ public class GuiElementCheckFieldAction extends AbstractCheckFieldAction {
 
         if (prevTimeout >= 0) {
             overrides.setTimeout(prevTimeout);
+        }
+        if (check.optional()) {
+            overrides.setAssertionImpl(previousAssertionImpl);
         }
     }
 

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/internal/action/GuiElementCheckFieldAction.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/internal/action/GuiElementCheckFieldAction.java
@@ -79,7 +79,7 @@ public class GuiElementCheckFieldAction extends AbstractCheckFieldAction {
         }
 
         /**
-         * It does not make sense to set both flags optional and collected!
+         * It does not make sense to set both flags optional and collect!
          *
          * Because an optional assertion is always collected but without PageFactoryException
          * the 'optional' is prioritised over 'collected'.
@@ -88,7 +88,7 @@ public class GuiElementCheckFieldAction extends AbstractCheckFieldAction {
 
         // Handling collected assertions
         Assertion previousAssertionImpl = null;
-        if (check.collected() && !check.optional()) {
+        if (check.collect() && !check.optional()) {
             CollectedAssertion assertionImpl = Testerra.getInjector().getInstance(CollectedAssertion.class);
             previousAssertionImpl = overrides.setAssertionImpl(assertionImpl);
         }
@@ -124,7 +124,7 @@ public class GuiElementCheckFieldAction extends AbstractCheckFieldAction {
         if (prevTimeout >= 0) {
             overrides.setTimeout(prevTimeout);
         }
-        if (check.optional() || check.collected()) {
+        if (check.optional() || check.collect()) {
             overrides.setAssertionImpl(previousAssertionImpl);
         }
     }

--- a/integration-tests/src/main/java/eu/tsystems/mms/tic/testframework/core/pageobjects/testdata/PageWithCollectedAndOptionalElement.java
+++ b/integration-tests/src/main/java/eu/tsystems/mms/tic/testframework/core/pageobjects/testdata/PageWithCollectedAndOptionalElement.java
@@ -28,10 +28,10 @@ import org.openqa.selenium.WebDriver;
 
 public class PageWithCollectedAndOptionalElement extends Page {
 
-    @Check(collected = true, optional = true)
+    @Check(collect = true, optional = true)
     private UiElement collectedElement1 = findById("NOT_EXISTING_WUWUWUWU_1");
 
-    @Check(collected = true, optional = true)
+    @Check(collect = true, optional = true)
     private UiElement collectedElement2 = findById("NOT_EXISTING_WUWUWUWU_2");
 
     /**

--- a/integration-tests/src/main/java/eu/tsystems/mms/tic/testframework/core/pageobjects/testdata/PageWithCollectedAndOptionalElement.java
+++ b/integration-tests/src/main/java/eu/tsystems/mms/tic/testframework/core/pageobjects/testdata/PageWithCollectedAndOptionalElement.java
@@ -1,0 +1,45 @@
+/*
+ * Testerra
+ *
+ * (C) 2020, Peter Lehmann, T-Systems Multimedia Solutions GmbH, Deutsche Telekom AG
+ *
+ * Deutsche Telekom AG and all other contributors /
+ * copyright owners license this file to you under the Apache
+ * License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package eu.tsystems.mms.tic.testframework.core.pageobjects.testdata;
+
+import eu.tsystems.mms.tic.testframework.pageobjects.Check;
+import eu.tsystems.mms.tic.testframework.pageobjects.Page;
+import eu.tsystems.mms.tic.testframework.pageobjects.UiElement;
+import org.openqa.selenium.WebDriver;
+
+public class PageWithCollectedAndOptionalElement extends Page {
+
+    @Check(collected = true, optional = true)
+    private UiElement collectedElement1 = findById("NOT_EXISTING_WUWUWUWU_1");
+
+    @Check(collected = true, optional = true)
+    private UiElement collectedElement2 = findById("NOT_EXISTING_WUWUWUWU_2");
+
+    /**
+     * Constructor for existing sessions.
+     *
+     * @param driver .
+     */
+    public PageWithCollectedAndOptionalElement(WebDriver driver) {
+        super(driver);
+    }
+}

--- a/integration-tests/src/main/java/eu/tsystems/mms/tic/testframework/core/pageobjects/testdata/PageWithCollectedAndOptionalElement.java
+++ b/integration-tests/src/main/java/eu/tsystems/mms/tic/testframework/core/pageobjects/testdata/PageWithCollectedAndOptionalElement.java
@@ -1,7 +1,7 @@
 /*
  * Testerra
  *
- * (C) 2020, Peter Lehmann, T-Systems Multimedia Solutions GmbH, Deutsche Telekom AG
+ * (C) 2022, Martin Großmann, T-Systems Multimedia Solutions GmbH, Deutsche Telekom AG
  *
  * Deutsche Telekom AG and all other contributors /
  * copyright owners license this file to you under the Apache

--- a/integration-tests/src/main/java/eu/tsystems/mms/tic/testframework/core/pageobjects/testdata/PageWithCollectedElement.java
+++ b/integration-tests/src/main/java/eu/tsystems/mms/tic/testframework/core/pageobjects/testdata/PageWithCollectedElement.java
@@ -28,10 +28,10 @@ import org.openqa.selenium.WebDriver;
 
 public class PageWithCollectedElement extends Page {
 
-    @Check(collected = true)
+    @Check(collect = true)
     private UiElement collectedElement1 = findById("NOT_EXISTING_WUWUWUWU_1");
 
-    @Check(collected = true)
+    @Check(collect = true)
     private UiElement collectedElement2 = findById("NOT_EXISTING_WUWUWUWU_2");
 
     /**

--- a/integration-tests/src/main/java/eu/tsystems/mms/tic/testframework/core/pageobjects/testdata/PageWithCollectedElement.java
+++ b/integration-tests/src/main/java/eu/tsystems/mms/tic/testframework/core/pageobjects/testdata/PageWithCollectedElement.java
@@ -1,0 +1,45 @@
+/*
+ * Testerra
+ *
+ * (C) 2020, Peter Lehmann, T-Systems Multimedia Solutions GmbH, Deutsche Telekom AG
+ *
+ * Deutsche Telekom AG and all other contributors /
+ * copyright owners license this file to you under the Apache
+ * License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package eu.tsystems.mms.tic.testframework.core.pageobjects.testdata;
+
+import eu.tsystems.mms.tic.testframework.pageobjects.Check;
+import eu.tsystems.mms.tic.testframework.pageobjects.Page;
+import eu.tsystems.mms.tic.testframework.pageobjects.UiElement;
+import org.openqa.selenium.WebDriver;
+
+public class PageWithCollectedElement extends Page {
+
+    @Check(collected = true)
+    private UiElement collectedElement1 = findById("NOT_EXISTING_WUWUWUWU_1");
+
+    @Check(collected = true)
+    private UiElement collectedElement2 = findById("NOT_EXISTING_WUWUWUWU_2");
+
+    /**
+     * Constructor for existing sessions.
+     *
+     * @param driver .
+     */
+    public PageWithCollectedElement(WebDriver driver) {
+        super(driver);
+    }
+}

--- a/integration-tests/src/main/java/eu/tsystems/mms/tic/testframework/core/pageobjects/testdata/PageWithCollectedElement.java
+++ b/integration-tests/src/main/java/eu/tsystems/mms/tic/testframework/core/pageobjects/testdata/PageWithCollectedElement.java
@@ -1,7 +1,7 @@
 /*
  * Testerra
  *
- * (C) 2020, Peter Lehmann, T-Systems Multimedia Solutions GmbH, Deutsche Telekom AG
+ * (C) 2022, Martin Großmann, T-Systems Multimedia Solutions GmbH, Deutsche Telekom AG
  *
  * Deutsche Telekom AG and all other contributors /
  * copyright owners license this file to you under the Apache

--- a/integration-tests/src/main/java/eu/tsystems/mms/tic/testframework/core/pageobjects/testdata/PageWithOptionalElement.java
+++ b/integration-tests/src/main/java/eu/tsystems/mms/tic/testframework/core/pageobjects/testdata/PageWithOptionalElement.java
@@ -1,7 +1,7 @@
 /*
  * Testerra
  *
- * (C) 2020, Peter Lehmann, T-Systems Multimedia Solutions GmbH, Deutsche Telekom AG
+ * (C) 2022, Martin Großmann, T-Systems Multimedia Solutions GmbH, Deutsche Telekom AG
  *
  * Deutsche Telekom AG and all other contributors /
  * copyright owners license this file to you under the Apache

--- a/integration-tests/src/main/java/eu/tsystems/mms/tic/testframework/core/pageobjects/testdata/PageWithOptionalElement.java
+++ b/integration-tests/src/main/java/eu/tsystems/mms/tic/testframework/core/pageobjects/testdata/PageWithOptionalElement.java
@@ -1,0 +1,42 @@
+/*
+ * Testerra
+ *
+ * (C) 2020, Peter Lehmann, T-Systems Multimedia Solutions GmbH, Deutsche Telekom AG
+ *
+ * Deutsche Telekom AG and all other contributors /
+ * copyright owners license this file to you under the Apache
+ * License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package eu.tsystems.mms.tic.testframework.core.pageobjects.testdata;
+
+import eu.tsystems.mms.tic.testframework.pageobjects.Check;
+import eu.tsystems.mms.tic.testframework.pageobjects.Page;
+import eu.tsystems.mms.tic.testframework.pageobjects.UiElement;
+import org.openqa.selenium.WebDriver;
+
+public class PageWithOptionalElement extends Page {
+
+    @Check(optional = true)
+    private UiElement optionalElement = findById("NOT_EXISTING_WUWUWUWU");
+
+    /**
+     * Constructor for existing sessions.
+     *
+     * @param driver .
+     */
+    public PageWithOptionalElement(WebDriver driver) {
+        super(driver);
+    }
+}

--- a/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/pagefactory/CheckPageTest.java
+++ b/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/pagefactory/CheckPageTest.java
@@ -31,6 +31,7 @@ import eu.tsystems.mms.tic.testframework.core.pageobjects.testdata.PageWithExist
 import eu.tsystems.mms.tic.testframework.core.pageobjects.testdata.PageWithNonCheckableCheck;
 import eu.tsystems.mms.tic.testframework.core.pageobjects.testdata.PageWithNotExistingElement;
 import eu.tsystems.mms.tic.testframework.core.pageobjects.testdata.PageWithNullElement;
+import eu.tsystems.mms.tic.testframework.core.pageobjects.testdata.PageWithOptionalElement;
 import eu.tsystems.mms.tic.testframework.exceptions.PageFactoryException;
 import eu.tsystems.mms.tic.testframework.testing.PageFactoryProvider;
 import org.testng.annotations.Test;
@@ -80,6 +81,11 @@ public class CheckPageTest extends AbstractTestSitesTest implements PageFactoryP
     @Test()
     public void testT09_checkCheckRule_IsNotPresent() {
         PAGE_FACTORY.createPage(PageWithCheckRuleIsNotPresent.class, getClassExclusiveWebDriver());
+    }
+
+    @Test
+    public void testT10_checkOptionalElement_IsNotPresent() {
+        PAGE_FACTORY.createPage(PageWithOptionalElement.class, getClassExclusiveWebDriver());
     }
 
 }

--- a/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/pagefactory/CheckPageTest.java
+++ b/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/pagefactory/CheckPageTest.java
@@ -22,10 +22,14 @@
 package eu.tsystems.mms.tic.testframework.test.pagefactory;
 
 import eu.tsystems.mms.tic.testframework.AbstractTestSitesTest;
+import eu.tsystems.mms.tic.testframework.annotations.Fails;
+import eu.tsystems.mms.tic.testframework.common.Testerra;
 import eu.tsystems.mms.tic.testframework.core.pageobjects.testdata.PageWithCheckRuleIsDisplayed;
 import eu.tsystems.mms.tic.testframework.core.pageobjects.testdata.PageWithCheckRuleIsNotDisplayed;
 import eu.tsystems.mms.tic.testframework.core.pageobjects.testdata.PageWithCheckRuleIsNotPresent;
 import eu.tsystems.mms.tic.testframework.core.pageobjects.testdata.PageWithCheckRuleIsPresent;
+import eu.tsystems.mms.tic.testframework.core.pageobjects.testdata.PageWithCollectedAndOptionalElement;
+import eu.tsystems.mms.tic.testframework.core.pageobjects.testdata.PageWithCollectedElement;
 import eu.tsystems.mms.tic.testframework.core.pageobjects.testdata.PageWithExistingElement;
 import eu.tsystems.mms.tic.testframework.core.pageobjects.testdata.PageWithExistingStaticElement;
 import eu.tsystems.mms.tic.testframework.core.pageobjects.testdata.PageWithNonCheckableCheck;
@@ -33,8 +37,18 @@ import eu.tsystems.mms.tic.testframework.core.pageobjects.testdata.PageWithNotEx
 import eu.tsystems.mms.tic.testframework.core.pageobjects.testdata.PageWithNullElement;
 import eu.tsystems.mms.tic.testframework.core.pageobjects.testdata.PageWithOptionalElement;
 import eu.tsystems.mms.tic.testframework.exceptions.PageFactoryException;
+import eu.tsystems.mms.tic.testframework.report.model.context.ClassContext;
+import eu.tsystems.mms.tic.testframework.report.model.context.ErrorContext;
+import eu.tsystems.mms.tic.testframework.report.model.context.MethodContext;
+import eu.tsystems.mms.tic.testframework.report.utils.IExecutionContextController;
 import eu.tsystems.mms.tic.testframework.testing.PageFactoryProvider;
+import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class CheckPageTest extends AbstractTestSitesTest implements PageFactoryProvider {
 
@@ -86,6 +100,35 @@ public class CheckPageTest extends AbstractTestSitesTest implements PageFactoryP
     @Test
     public void testT10_checkOptionalElement_IsNotPresent() {
         PAGE_FACTORY.createPage(PageWithOptionalElement.class, getClassExclusiveWebDriver());
+    }
+
+    @Test(priority = 1)
+    @Fails(description = "The test itself passes, but collected assertions will always fail")
+    public void testT11_checkCollectedElements_IsNotPresent() {
+        PAGE_FACTORY.createPage(PageWithCollectedElement.class, getClassExclusiveWebDriver());
+    }
+
+    @Test(priority = 2)
+    public void testT11a_checkCollectedElements_verifyResult() {
+        IExecutionContextController instance = Testerra.getInjector().getInstance(IExecutionContextController.class);
+        Optional<Stream<ErrorContext>> errorContextStream = ((ClassContext) instance.getCurrentMethodContext().get().getParentContext())
+                .readMethodContexts()
+                .filter(context -> context.getName().equals("testT11_checkCollectedElements_IsNotPresent"))
+                .findFirst()
+                .map(MethodContext::readErrors);
+        Assert.assertTrue(errorContextStream.isPresent());
+        List<String> errorList = errorContextStream.get().map(context -> context.getThrowable().getMessage()).collect(Collectors.toList());
+        Assert.assertEquals(errorList.size(), 2, "Method context should contains 2 errors.");
+
+        Assert.assertTrue(errorList.contains("Expected that PageWithCollectedElement -> collectedElement1 displayed is true"));
+        Assert.assertTrue(errorList.contains("Expected that PageWithCollectedElement -> collectedElement2 displayed is true"));
+    }
+
+    @Test
+    public void testT12_checkCollectedAndOptionalElements_IsNotPresent() {
+        // The used page is bad practice, but possible:
+        // In case of 'optional' AND 'collected' elements the 'optional' wins.
+        PAGE_FACTORY.createPage(PageWithCollectedAndOptionalElement.class, getClassExclusiveWebDriver());
     }
 
 }

--- a/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/pagefactory/CheckPageTest.java
+++ b/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/pagefactory/CheckPageTest.java
@@ -111,13 +111,12 @@ public class CheckPageTest extends AbstractTestSitesTest implements PageFactoryP
     @Test(priority = 2)
     public void testT11a_checkCollectedElements_verifyResult() {
         IExecutionContextController instance = Testerra.getInjector().getInstance(IExecutionContextController.class);
-        Optional<Stream<ErrorContext>> errorContextStream = ((ClassContext) instance.getCurrentMethodContext().get().getParentContext())
+        List<String> errorList = ((ClassContext) instance.getCurrentMethodContext().get().getParentContext())
                 .readMethodContexts()
-                .filter(context -> context.getName().equals("testT11_checkCollectedElements_IsNotPresent"))
-                .findFirst()
-                .map(MethodContext::readErrors);
-        Assert.assertTrue(errorContextStream.isPresent());
-        List<String> errorList = errorContextStream.get().map(context -> context.getThrowable().getMessage()).collect(Collectors.toList());
+                .filter(context -> "testT11_checkCollectedElements_IsNotPresent".equals(context.getName()))
+                .flatMap(MethodContext::readErrors)
+                .map(context -> context.getThrowable().getMessage())
+                .collect(Collectors.toList());
         Assert.assertEquals(errorList.size(), 2, "Method context should contains 2 errors.");
 
         Assert.assertTrue(errorList.contains("Expected that PageWithCollectedElement -> collectedElement1 displayed is true"));


### PR DESCRIPTION
# Description

Added the `collect` attribute for `@Check`:
````java
@Check(collect = true)
private UiElement uiElement = find(...);
````
Also fixed the `optional` attribute which was not working properly.

Fixes #207 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
