### PR TITLE
Fix/report session video size

### DIFF
--- a/report-ng/app/src/components/lazy-video/lazy-video.html
+++ b/report-ng/app/src/components/lazy-video/lazy-video.html
@@ -19,5 +19,5 @@
   ~ under the License.
   -->
 <template>
-    <video width="100%" controls ref="_videoElement"></video>
+    <video controls ref="_videoElement"></video>
 </template>

--- a/report-ng/app/src/components/lazy-video/lazy-video.scss
+++ b/report-ng/app/src/components/lazy-video/lazy-video.scss
@@ -1,7 +1,7 @@
 /*!
  * Testerra
  *
- * (C) 2021, Mike Reiche,  T-Systems Multimedia Solutions GmbH, Deutsche Telekom AG
+ * (C) 2022, Martin Großmann,  T-Systems Multimedia Solutions GmbH, Deutsche Telekom AG
  *
  * Deutsche Telekom AG and all other contributors /
  * copyright owners license this file to you under the Apache
@@ -19,9 +19,14 @@
  * under the License.
  */
 
-.capabilities-view {
-    height: 300px;
-    width: 350px;
-    overflow-y: scroll;
-    white-space: break-spaces;
+@media screen and (min-width: 1024px) {
+    video { height: 300px; }
+}
+
+@media screen and (min-width: 1280px) {
+    video { height: 400px; }
+}
+
+@media screen and (min-width: 1920px) {
+    video { height: 600px; }
 }

--- a/report-ng/app/src/components/lazy-video/lazy-video.scss
+++ b/report-ng/app/src/components/lazy-video/lazy-video.scss
@@ -19,14 +19,14 @@
  * under the License.
  */
 
-@media screen and (min-width: 1024px) {
-    video { height: 300px; }
+@media screen and (min-width: 0px) {
+    video { height: 20em; }
 }
 
 @media screen and (min-width: 1280px) {
-    video { height: 400px; }
+    video { height: 30em; }
 }
 
 @media screen and (min-width: 1920px) {
-    video { height: 600px; }
+    video { height: 40em; }
 }

--- a/report-ng/app/src/components/lazy-video/lazy-video.ts
+++ b/report-ng/app/src/components/lazy-video/lazy-video.ts
@@ -24,6 +24,7 @@ import {bindable} from "aurelia-templating";
 import {bindingMode} from "aurelia-binding";
 import {StatisticsGenerator} from "../../services/statistics-generator";
 import {ObjectStorage} from "t-systems-aurelia-components/src/utils/object-storage";
+import "./lazy-video.scss"
 
 interface IVideoInfo {
     time:number;
@@ -55,6 +56,7 @@ export class LazyVideo {
                 this._videoElement.currentTime = videoInfo.time;
             }
         });
+        console.log("Video", this._videoElement.height);
     }
 
     detached() {

--- a/report-ng/app/src/components/lazy-video/lazy-video.ts
+++ b/report-ng/app/src/components/lazy-video/lazy-video.ts
@@ -56,7 +56,6 @@ export class LazyVideo {
                 this._videoElement.currentTime = videoInfo.time;
             }
         });
-        console.log("Video", this._videoElement.height);
     }
 
     detached() {


### PR DESCRIPTION
# Description

In case of session videos in portrait mode (mobile devices) the videos are to height for the session view. This change fixes the  video tag height according screen size. 
I also fixed the width of the capability view behind the video. For some appium servers you need an authentication key which expand the view. The y scrolling was not working without `width: .. px`.

New view:
![image](https://user-images.githubusercontent.com/22025965/189920191-107e2a82-a827-4c78-b17e-ac1f9db08c1a.png)


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
