### PR TITLE
Fixed creating screenshots of non-existing sessions

### DIFF
--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/utils/UITestUtils.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/utils/UITestUtils.java
@@ -32,6 +32,7 @@ import eu.tsystems.mms.tic.testframework.report.model.context.Screenshot;
 import eu.tsystems.mms.tic.testframework.report.model.context.SessionContext;
 import eu.tsystems.mms.tic.testframework.report.utils.IExecutionContextController;
 import eu.tsystems.mms.tic.testframework.testing.WebDriverManagerProvider;
+import eu.tsystems.mms.tic.testframework.webdrivermanager.WebDriverSessionsManager;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.Rectangle;
 import org.openqa.selenium.TakesScreenshot;
@@ -332,8 +333,9 @@ public class UITestUtils implements WebDriverManagerProvider {
 
         // Find all sessions of current method context and create screenshots
         Stream<Screenshot> screenshotStream = methodContext.get().readSessionContexts()
-                .map(SessionContext::getSessionKey)
-                .map(WEB_DRIVER_MANAGER::getWebDriver)
+                .map(WebDriverSessionsManager::getWebDriver)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
                 .map(UITestUtils::pTakeAllScreenshotsForSession)
                 .flatMap(Collection::stream);
 


### PR DESCRIPTION
# Description

Fixed `UiTestUtils::takeScreenshots`. If a Webdriver session does not exist anmore, `UiTestUtils` was trying to create a new one to create a final sreenshot.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
