### PR TITLE
Fix/platform cap handling

### DIFF
--- a/docs/src/docs/browser-caps.adoc
+++ b/docs/src/docs/browser-caps.adoc
@@ -9,4 +9,5 @@ You can customize your WebDriver session by setting capabilities in the followin
 When creating a new WebDriver, these capabilities get merged together in this exact order.
 
 include::browsercaps/common-browser-caps.adoc[leveloffset=+1]
+include::browsercaps/setting-browser-caps.adoc[leveloffset=+1]
 include::browsercaps/proxy-setup.adoc[leveloffset=+1]

--- a/docs/src/docs/browsercaps/common-browser-caps.adoc
+++ b/docs/src/docs/browsercaps/common-browser-caps.adoc
@@ -1,59 +1,28 @@
-= Global capabilities
+= Common browser capabilities
 
-You can customize your browser session by setting capabilities for every browser type before
-the WebDriver has been initialized.
+include::../properties/property-attributes.adoc[]
 
-[source,java]
-----
-WEB_DRIVER_MANAGER.setGlobalCapability(CapabilityType.ACCEPT_INSECURE_CERTS, true);
-WEB_DRIVER_MANAGER.removeGlobalCapability(CapabilityType.ACCEPT_INSECURE_CERTS);
-----
+The following table shows the most used browser capabilities and how they can set.
 
-[IMPORTANT]
-====
-Do NOT set browser capabilities with WebDriverManager like:
+[cols="1,1a,1a,1a"]
+|===
+|Capability | Selenium type | test.properties | DesktopWebDriverRequest
 
-[source, java]
-----
-FirefoxOptions options = new FirefoxOptions();
-options.addPreference("intl.accept_languages", "de-DE");
-// This cannot be merged correctly!
-WEB_DRIVER_MANAGER.setGlobalCapability(FirefoxOptions.FIREFOX_OPTIONS, options);
-----
+| Browser type
+| `CapabilityType.BROWSER_NAME`
+| `{browser_setting}`, `{browser}`
+| `setBrowser(String)`
 
-====
+| Browser version
+| `CapabilityType.BROWSER_VERSION`
+| `{browser_setting}`, `{browser_version}`
+| `setBrowserVersion(String)`
 
-= Request capabilities
+| Platform
+| `CapabilityType.PLATFORM_NAME` *
+| `{browser_setting}`, `{browser_platform}`
+| `setPlatformName(String)`
 
-Some WebDriverRequests support setting capabilities, like the `DesktopWebDriverRequest`.
+|===
 
-.Set capabilities to a DesktopWebDriverRequest object
-[source,java]
-----
-DesktopWebDriverRequest request = new DesktopWebDriverRequest();
-DesiredCapabilities caps = request.getDesiredCapabilities();
-caps.setCapability(CapabilityType.ACCEPT_INSECURE_CERTS, true);
-// Start your session with the DesktopWebDriverRequest object
-WebDriver webDriver = WEB_DRIVER_MANAGER.getWebDriver(request);
-----
-
-[NOTE]
-=====
-Have a look into <<Browser specific knowledge>> for specific browser options. +
-Find some more details for `DesktopWebDriverRequest` at <<_request_configuration>>.
-=====
-
-= User agent configuration
-
-The user agent configuration is most precise, because it provides explicit browser options based on the Selenium driver.
-
-[source, java]
-----
-import eu.tsystems.mms.tic.testframework.useragents.FirefoxConfig;
-
-WEB_DRIVER_MANAGER.setUserAgentConfig(Browsers.firefox, (FirefoxConfig) options -> {
-    options.addPreference("intl.accept_languages", "de-DE");
-});
-----
-
-NOTE: Have a look into <<Browser specific knowledge>> for specific browser options.
+{empty}* The capability `CapabilityType.PLATFORM` is deprecated and has to be set manually.

--- a/docs/src/docs/browsercaps/setting-browser-caps.adoc
+++ b/docs/src/docs/browsercaps/setting-browser-caps.adoc
@@ -1,0 +1,60 @@
+= User agent configuration
+
+The user agent configuration is most precise, because it provides explicit browser options based on the Selenium driver.
+
+[source, java]
+----
+import eu.tsystems.mms.tic.testframework.useragents.FirefoxConfig;
+
+WEB_DRIVER_MANAGER.setUserAgentConfig(Browsers.firefox, (FirefoxConfig) options -> {
+    options.addPreference("intl.accept_languages", "de-DE");
+});
+----
+
+NOTE: Have a look into <<Browser specific knowledge>> for specific browser options.
+
+= Request capabilities
+
+Some WebDriverRequests support setting capabilities, like the `DesktopWebDriverRequest`. It's used to specify a single WebDriver session.
+
+.Set capabilities to a DesktopWebDriverRequest object
+[source,java]
+----
+DesktopWebDriverRequest request = new DesktopWebDriverRequest();
+DesiredCapabilities caps = request.getDesiredCapabilities();
+caps.setCapability(CapabilityType.ACCEPT_INSECURE_CERTS, true);
+// Start your session with the DesktopWebDriverRequest object
+WebDriver webDriver = WEB_DRIVER_MANAGER.getWebDriver(request);
+----
+
+[NOTE]
+=====
+Have a look into <<Browser specific knowledge>> for specific browser options. +
+Find some more details for `DesktopWebDriverRequest` at <<_request_configuration>>.
+=====
+
+= Global capabilities
+
+You can customize your browser session by setting capabilities for every browser type.
+
+Be in mind that not every browser could handle all types of capabilities.
+
+[source,java]
+----
+WEB_DRIVER_MANAGER.setGlobalCapability(CapabilityType.ACCEPT_INSECURE_CERTS, true);
+WEB_DRIVER_MANAGER.removeGlobalCapability(CapabilityType.ACCEPT_INSECURE_CERTS);
+----
+
+[IMPORTANT]
+====
+Do NOT set browser capabilities with WebDriverManager. This will added to the capabilities to all browser types!
+
+[source, java]
+----
+FirefoxOptions options = new FirefoxOptions();
+options.addPreference("intl.accept_languages", "de-DE");
+// This cannot be merged correctly!
+WEB_DRIVER_MANAGER.setGlobalCapability(FirefoxOptions.FIREFOX_OPTIONS, options);
+----
+
+====

--- a/docs/src/docs/properties/webdriver-props.adoc
+++ b/docs/src/docs/properties/webdriver-props.adoc
@@ -6,7 +6,7 @@ include::property-attributes.adoc[]
 | Property | default | Description
 
 | {browser_setting} | na.
-a| Define the user agent configuration like `browser[:version[:platform]]` (example: `firefox:65:windows`). Overrides {browser}, {browser_version} and {browser_platform} (recommended).
+a| Define the user agent configuration like `browser[:version[:platform]]` (example: `firefox:65:windows`). Overrides `{browser}`, `{browser_version}` and `{browser_platform}` (recommended).
 
 The following types of browsers are supported:
 

--- a/driver-ui-desktop/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/DesktopWebDriverFactory.java
+++ b/driver-ui-desktop/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/DesktopWebDriverFactory.java
@@ -37,20 +37,10 @@ import eu.tsystems.mms.tic.testframework.report.model.context.SessionContext;
 import eu.tsystems.mms.tic.testframework.report.utils.ExecutionContextUtils;
 import eu.tsystems.mms.tic.testframework.testing.TestControllerProvider;
 import eu.tsystems.mms.tic.testframework.testing.WebDriverManagerProvider;
-import eu.tsystems.mms.tic.testframework.utils.DefaultCapabilityUtils;
 import eu.tsystems.mms.tic.testframework.utils.FileUtils;
 import eu.tsystems.mms.tic.testframework.utils.Sleepy;
 import eu.tsystems.mms.tic.testframework.utils.TimerUtils;
 import eu.tsystems.mms.tic.testframework.webdriver.WebDriverFactory;
-import eu.tsystems.mms.tic.testframework.webdrivermanager.desktop.WebDriverMode;
-import java.io.File;
-import java.lang.reflect.Constructor;
-import java.net.URL;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
 import net.anthavio.phanbedder.Phanbedder;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.Dimension;
@@ -67,7 +57,6 @@ import org.openqa.selenium.ie.InternetExplorerOptions;
 import org.openqa.selenium.phantomjs.PhantomJSDriver;
 import org.openqa.selenium.phantomjs.PhantomJSDriverService;
 import org.openqa.selenium.remote.BrowserType;
-import org.openqa.selenium.remote.CapabilityType;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.HttpCommandExecutor;
 import org.openqa.selenium.remote.LocalFileDetector;
@@ -76,20 +65,28 @@ import org.openqa.selenium.safari.SafariDriver;
 import org.openqa.selenium.safari.SafariOptions;
 import org.openqa.selenium.support.events.EventFiringWebDriver;
 
+import java.io.File;
+import java.lang.reflect.Constructor;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
 public class DesktopWebDriverFactory implements
         WebDriverFactory,
         Loggable,
         WebDriverManagerProvider,
         TestControllerProvider,
-        Sleepy
-{
+        Sleepy {
     //public static final TimingInfosCollector STARTUP_TIME_COLLECTOR = new TimingInfosCollector();
 
     private static File phantomjsFile = null;
 
     @Override
     public WebDriver createWebDriver(WebDriverRequest request, SessionContext sessionContext) {
-        return startSession((DesktopWebDriverRequest)request, sessionContext);
+        return startSession((DesktopWebDriverRequest) request, sessionContext);
     }
 
     private WebDriver startSession(DesktopWebDriverRequest desktopWebDriverRequest, SessionContext sessionContext) {
@@ -204,17 +201,13 @@ public class DesktopWebDriverFactory implements
         if (userAgentCapabilities != null) {
             desiredCapabilities.merge(userAgentCapabilities);
         }
-        finalRequest.getPlatformName().ifPresent(s -> {
-            desiredCapabilities.setCapability(CapabilityType.PLATFORM, s);
-            desiredCapabilities.setCapability(CapabilityType.PLATFORM_NAME, s);
-        });
         return finalRequest;
     }
 
     @Override
     public void setupNewWebDriverSession(EventFiringWebDriver eventFiringWebDriver, SessionContext sessionContext) {
 
-        DesktopWebDriverRequest desktopWebDriverRequest = (DesktopWebDriverRequest)sessionContext.getWebDriverRequest();
+        DesktopWebDriverRequest desktopWebDriverRequest = (DesktopWebDriverRequest) sessionContext.getWebDriverRequest();
         final String browser = desktopWebDriverRequest.getBrowser();
 
         // add event listeners
@@ -333,7 +326,7 @@ public class DesktopWebDriverFactory implements
         try {
             newDriver = startNewWebDriverSession(desktopWebDriverRequest, sessionContext);
         } catch (final SetupException e) {
-            int ms = Testerra.Properties.WEBDRIVER_TIMEOUT_SECONDS_RETRY.asLong().intValue()*1000;
+            int ms = Testerra.Properties.WEBDRIVER_TIMEOUT_SECONDS_RETRY.asLong().intValue() * 1000;
             log().error(String.format("Error starting WebDriver. Trying again in %d seconds", (ms / 1000)), e);
             TimerUtils.sleep(ms);
             newDriver = startNewWebDriverSession(desktopWebDriverRequest, sessionContext);
@@ -418,13 +411,13 @@ public class DesktopWebDriverFactory implements
     @Override
     public List<String> getSupportedBrowsers() {
         return Arrays.asList(
-            Browsers.safari,
-            Browsers.ie,
-            Browsers.chrome,
-            Browsers.chromeHeadless,
-            Browsers.edge,
-            Browsers.firefox,
-            Browsers.phantomjs
+                Browsers.safari,
+                Browsers.ie,
+                Browsers.chrome,
+                Browsers.chromeHeadless,
+                Browsers.edge,
+                Browsers.firefox,
+                Browsers.phantomjs
         );
     }
 

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/AbstractWebDriverRequest.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/AbstractWebDriverRequest.java
@@ -22,14 +22,19 @@ package eu.tsystems.mms.tic.testframework.webdrivermanager;
 
 import eu.tsystems.mms.tic.testframework.common.PropertyManager;
 import eu.tsystems.mms.tic.testframework.constants.TesterraProperties;
+import eu.tsystems.mms.tic.testframework.logging.Loggable;
+import org.apache.commons.lang3.StringUtils;
+import org.openqa.selenium.Platform;
+import org.openqa.selenium.WebDriverException;
+import org.openqa.selenium.remote.CapabilityType;
+import org.openqa.selenium.remote.DesiredCapabilities;
+
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Map;
 import java.util.Optional;
-import org.apache.commons.lang3.StringUtils;
-import org.openqa.selenium.remote.DesiredCapabilities;
 
-public class AbstractWebDriverRequest implements WebDriverRequest {
+public class AbstractWebDriverRequest implements WebDriverRequest, Loggable {
 
     private String sessionKey = DEFAULT_SESSION_KEY;
     private URL serverUrl;
@@ -38,7 +43,6 @@ public class AbstractWebDriverRequest implements WebDriverRequest {
     private boolean shutdownAfterTestFailed = false;
     private boolean shutdownAfterExecution = true;
     private String browserName;
-    private String platformName;
 
     public AbstractWebDriverRequest() {
         setShutdownAfterTest(PropertyManager.getBooleanProperty(TesterraProperties.CLOSE_WINDOWS_AFTER_TEST_METHODS, true));
@@ -157,13 +161,21 @@ public class AbstractWebDriverRequest implements WebDriverRequest {
     }
 
     public void setPlatformName(String platformName) {
-        if (StringUtils.isNotBlank(platformName)) {
-            this.platformName = platformName;
+        try {
+            if (StringUtils.isNotBlank(platformName)) {
+                final Platform platform = Platform.fromString(platformName);
+                this.getDesiredCapabilities().setCapability(CapabilityType.PLATFORM_NAME, platform);
+            }
+        } catch (WebDriverException e) {
+            log().warn("Trying to set invalid platform '{}' was ignored.", platformName);
         }
     }
 
     public Optional<String> getPlatformName() {
-        return Optional.ofNullable(this.platformName);
+        if (this.getDesiredCapabilities().getPlatform() != null) {
+            return Optional.ofNullable(this.getDesiredCapabilities().getPlatform().toString());
+        }
+        return Optional.empty();
     }
 
 }

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/SeleniumWebDriverRequest.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/SeleniumWebDriverRequest.java
@@ -29,7 +29,7 @@ import java.net.URL;
 import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 
-public class SeleniumWebDriverRequest extends AbstractWebDriverRequest implements Loggable, Serializable {
+public class SeleniumWebDriverRequest extends AbstractWebDriverRequest implements Serializable {
 
     private URL baseUrl = null;
 

--- a/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/webdrivermanager/DesktopWebDriverFactoryTest.java
+++ b/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/webdrivermanager/DesktopWebDriverFactoryTest.java
@@ -21,18 +21,21 @@
 
 package eu.tsystems.mms.tic.testframework.test.webdrivermanager;
 
-import eu.tsystems.mms.tic.testframework.testing.TesterraTest;
 import eu.tsystems.mms.tic.testframework.report.model.context.SessionContext;
+import eu.tsystems.mms.tic.testframework.testing.TesterraTest;
+import eu.tsystems.mms.tic.testframework.testing.WebDriverManagerProvider;
 import eu.tsystems.mms.tic.testframework.webdrivermanager.DesktopWebDriverRequest;
-import eu.tsystems.mms.tic.testframework.webdrivermanager.WebDriverManager;
-import eu.tsystems.mms.tic.testframework.webdrivermanager.WebDriverSessionsManager;
-import java.util.Map;
+import eu.tsystems.mms.tic.testframework.webdrivermanager.WebDriverRequest;
+import org.openqa.selenium.Platform;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.remote.CapabilityType;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-public class DesktopWebDriverFactoryTest extends TesterraTest {
+import java.util.Map;
+
+public class DesktopWebDriverFactoryTest extends TesterraTest implements WebDriverManagerProvider {
 
     @Test
     public void testT01_BaseURL() throws Exception {
@@ -41,7 +44,7 @@ public class DesktopWebDriverFactoryTest extends TesterraTest {
         //request.webDriverMode = WebDriverMode.local;
         //request.browser = Browsers.phantomjs;
 
-        WebDriver driver = WebDriverManager.getWebDriver(request);
+        WebDriver driver = WEB_DRIVER_MANAGER.getWebDriver(request);
         String currentUrl = driver.getCurrentUrl();
         Assert.assertTrue(currentUrl.contains("google"), "Current URL contains google - actual: " + currentUrl);
     }
@@ -52,7 +55,7 @@ public class DesktopWebDriverFactoryTest extends TesterraTest {
         //request.webDriverMode = WebDriverMode.local;
         //request.browser = Browsers.phantomjs;
 
-        WebDriver driver = WebDriverManager.getWebDriver(request);
+        WebDriver driver = WEB_DRIVER_MANAGER.getWebDriver(request);
         String currentUrl = driver.getCurrentUrl();
         // Empty baseUrl of Chrome
         Assert.assertTrue(currentUrl.contains("data"), "Current URL is invalid - actual: " + currentUrl);
@@ -73,11 +76,22 @@ public class DesktopWebDriverFactoryTest extends TesterraTest {
         caps.setCapability("enableVNC", true);
 
         // start session
-        WebDriver driver = WebDriverManager.getWebDriver(request);
-        SessionContext sessionContext = WebDriverSessionsManager.getSessionContext(driver).get();
+        WebDriver driver = WEB_DRIVER_MANAGER.getWebDriver(request);
+        SessionContext sessionContext = WEB_DRIVER_MANAGER.getSessionContext(driver).get();
         Map<String, Object> sessionCapabilities = sessionContext.getWebDriverRequest().getCapabilities();
 
         Assert.assertEquals(sessionCapabilities.get("tap:projectId"), caps.getCapability("tap:projectId"), "EndPoint Capability is set");
+    }
+
+    @Test
+    public void testT04_PlatformCaps() {
+        DesktopWebDriverRequest request = new DesktopWebDriverRequest();
+        request.setPlatformName(Platform.LINUX.toString());
+        WebDriver driver = WEB_DRIVER_MANAGER.getWebDriver(request);
+
+        WebDriverRequest webDriverRequest = WEB_DRIVER_MANAGER.getSessionContext(driver).get().getWebDriverRequest();
+
+        Assert.assertEquals(webDriverRequest.getCapabilities().get(CapabilityType.PLATFORM_NAME), Platform.LINUX);
     }
 
 }


### PR DESCRIPTION
# Description

Changed setting the capability `platformName` to added directly to caps list of `DesktopWebDriverRequest`. Before it was stored as own property which could occure merging conflicts at preparing new request for a new session.

The depreacted capability `platform` was removed. It has to be added manually if still needed.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
