### PR TITLE
Fix UITestUtils for non-browser drivers

### DIFF
--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/utils/UITestUtils.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/utils/UITestUtils.java
@@ -87,7 +87,8 @@ public class UITestUtils implements WebDriverManagerProvider {
     }
 
     public static Screenshot takeScreenshot(final WebDriver driver, boolean intoReport) {
-        Screenshot screenshot = takeScreenshot(driver, driver.getWindowHandle());
+        String handle = executionUtils.getFailsafe(driver::getWindowHandle).orElse("");
+        Screenshot screenshot = takeScreenshot(driver, handle);
 
         if (intoReport) {
             IExecutionContextController executionContextController = Testerra.getInjector().getInstance(IExecutionContextController.class);
@@ -288,6 +289,7 @@ public class UITestUtils implements WebDriverManagerProvider {
             }
         }, () -> {
             try {
+                // Some drivers like AppiumDriver for native apps has no window handles
                 Screenshot screenshot = takeScreenshot(webDriver, "");
                 screenshots.add(screenshot);
             } catch (Throwable t) {

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/utils/UITestUtils.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/utils/UITestUtils.java
@@ -155,7 +155,7 @@ public class UITestUtils implements WebDriverManagerProvider {
         return screenshot;
     }
 
-    public static void takeWebDriverScreenshotToFile(WebDriver eventFiringWebDriver, File screenShotTargetFile) {
+    private static void takeWebDriverScreenshotToFile(WebDriver eventFiringWebDriver, File screenShotTargetFile) {
         WebDriver driver;
         if (eventFiringWebDriver instanceof EventFiringWebDriver) {
             driver = ((EventFiringWebDriver) eventFiringWebDriver).getWrappedDriver();

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/utils/UITestUtils.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/utils/UITestUtils.java
@@ -38,13 +38,9 @@ import org.openqa.selenium.Rectangle;
 import org.openqa.selenium.TakesScreenshot;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.support.events.EventFiringWebDriver;
-import org.sikuli.api.ScreenLocation;
-import org.sikuli.api.ScreenRegion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.imageio.ImageIO;
-import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
@@ -54,7 +50,6 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -192,23 +187,6 @@ public class UITestUtils implements WebDriverManagerProvider {
     }
 
     /**
-     * Utility to store a Screenshot at the specified location.
-     *
-     * @param image BufferedImage
-     * @param targetFile filePath with fileName
-     */
-    private static void saveBufferedImage(BufferedImage image, File targetFile) {
-        try {
-            ImageIO.write(image, "png", targetFile);
-        } catch (final FileNotFoundException ex) {
-            LoggerFactory.getLogger(UITestUtils.class).warn(
-                    ("Screenshot file could not be written to file system: " + ex.toString()));
-        } catch (final IOException ioe) {
-            LoggerFactory.getLogger(UITestUtils.class).warn(ioe.toString());
-        }
-    }
-
-    /**
      * Save page source to file.
      *
      * @param pageSource page source.
@@ -225,24 +203,6 @@ public class UITestUtils implements WebDriverManagerProvider {
                     ("PageSource file could not be written to file system: " + ex.toString()));
         } catch (final IOException ioe) {
             LoggerFactory.getLogger(UITestUtils.class).warn(ioe.toString());
-        }
-    }
-
-    public static void takeScreenshot(ScreenRegion screenRegion) {
-        if (screenRegion != null) {
-            LOGGER.info("Taking screenshot from desktop");
-            final ScreenLocation upperLeftCorner = screenRegion.getUpperLeftCorner();
-            final ScreenLocation lowerRightCorner = screenRegion.getLowerRightCorner();
-            final BufferedImage screenshotImage = screenRegion.getScreen()
-                    .getScreenshot(upperLeftCorner.getX(), upperLeftCorner.getY(), lowerRightCorner.getX(), lowerRightCorner.getY());
-
-            final String filename = "Desktop_" + FILES_DATE_FORMAT.format(new Date()) + ".png";
-            Screenshot screenshot = new Screenshot(filename);
-            Report report = Testerra.getInjector().getInstance(Report.class);
-            saveBufferedImage(screenshotImage, screenshot.getScreenshotFile());
-            report.addScreenshot(screenshot, Report.FileMode.MOVE);
-        } else {
-            LOGGER.error("Could not take native screenshot, screen region is missing");
         }
     }
 

--- a/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/playground/DriverAndGuiElementTest.java
+++ b/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/playground/DriverAndGuiElementTest.java
@@ -24,13 +24,16 @@
 import eu.tsystems.mms.tic.testframework.AbstractTestSitesTest;
 import eu.tsystems.mms.tic.testframework.constants.Browsers;
 import eu.tsystems.mms.tic.testframework.core.pageobjects.testdata.PageWithExistingElement;
+import eu.tsystems.mms.tic.testframework.core.pageobjects.testdata.PageWithNotExistingElement;
 import eu.tsystems.mms.tic.testframework.pageobjects.UiElement;
 import eu.tsystems.mms.tic.testframework.pageobjects.UiElementFinder;
 import eu.tsystems.mms.tic.testframework.pageobjects.factory.PageFactory;
 import eu.tsystems.mms.tic.testframework.report.model.context.SessionContext;
+import eu.tsystems.mms.tic.testframework.testing.PageFactoryProvider;
 import eu.tsystems.mms.tic.testframework.testing.TesterraTest;
 import eu.tsystems.mms.tic.testframework.testing.UiElementFinderFactoryProvider;
 import eu.tsystems.mms.tic.testframework.testing.WebDriverManagerProvider;
+import eu.tsystems.mms.tic.testframework.utils.UITestUtils;
 import eu.tsystems.mms.tic.testframework.webdrivermanager.DesktopWebDriverRequest;
 import eu.tsystems.mms.tic.testframework.webdrivermanager.WebDriverSessionsManager;
 import eu.tsystems.mms.tic.testframework.webdrivermanager.desktop.WebDriverMode;
@@ -42,7 +45,7 @@ import org.openqa.selenium.remote.DesiredCapabilities;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-public class DriverAndGuiElementTest extends AbstractTestSitesTest implements UiElementFinderFactoryProvider {
+public class DriverAndGuiElementTest extends AbstractTestSitesTest implements UiElementFinderFactoryProvider, PageFactoryProvider {
 
     @Test
     public void testUiElement() throws Exception {
@@ -85,5 +88,14 @@ public class DriverAndGuiElementTest extends AbstractTestSitesTest implements Ui
 
         WEB_DRIVER_MANAGER.getWebDriver(request);
         Assert.assertTrue(false);
+    }
+
+    @Test
+    public void testT02_checkNotExistingElement() {
+        WebDriver webDriver = this.getWebDriver();
+
+//        PAGE_FACTORY.createPage(PageWithNotExistingElement.class);
+        PAGE_FACTORY.createPage(PageWithExistingElement.class, webDriver);
+        UITestUtils.takeScreenshot(webDriver, true);
     }
 }


### PR DESCRIPTION
# Description

Creating screenshots via `UITestUtils` was not safe for non-browser drivers like Appium drivers. Some called methods are not supported by Appium.

I also removed old stuff like taking screenshots with Sikuli `ScreenRegion` because it's only work local but not with remote Selenium servers.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
