### PR TITLE
Updated handling of ClassContext name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ gradlew
 /integration-tests/chromedriver.exe
 /report-ng/app/static/assets/model/
 /report-ng-tests/src/test/resources/reports/report-generated-status/
+/report-ng-tests/src/test/resources/reports/report-extended-status/

--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/report/model/context/TestContext.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/report/model/context/TestContext.java
@@ -65,7 +65,8 @@ public class TestContext extends AbstractContext {
      */
     public ClassContext getClassContext(final ITestNGMethod iTestNgMethod) {
         final IClass testClass = iTestNgMethod.getTestClass();
-        return this.pGetClassContext(testClass, testClass.getRealClass().getSimpleName());
+//        return this.pGetClassContext(testClass, testClass.getRealClass().getSimpleName());
+        return this.pGetClassContext(testClass, testClass.getRealClass().getName());
     }
 
     private synchronized ClassContext pGetClassContext(IClass testClass, String classContextName) {

--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/report/utils/DefaultTestNGContextGenerator.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/report/utils/DefaultTestNGContextGenerator.java
@@ -29,7 +29,8 @@ public class DefaultTestNGContextGenerator implements TestNGContextNameGenerator
 
     @Override
     public String getClassContextName(ITestResult testResult) {
-        return testResult.getTestClass().getRealClass().getSimpleName();
+//        return testResult.getTestClass().getRealClass().getSimpleName();
+        return testResult.getTestClass().getRealClass().getName();
     }
 
     @Override

--- a/docs/src/docs/pageobject/components.adoc
+++ b/docs/src/docs/pageobject/components.adoc
@@ -45,8 +45,8 @@ The second parameter is the *root element* of your component (here the `div` ele
 ----
 public class MyPage extends Page {
 
-    @Check
     MyComponent component = createComponent(MyComponent.class, find(By.id("container")));
+
 }
 ----
 

--- a/report-ng-tests/src/main/java/io/testerra/report/test/pages/report/sideBarPages/ReportLogsPage.java
+++ b/report-ng-tests/src/main/java/io/testerra/report/test/pages/report/sideBarPages/ReportLogsPage.java
@@ -69,7 +69,7 @@ public class ReportLogsPage extends AbstractReportPage {
             if (markedLineParts.list().size() > 0) {
                 if (!markedLineParts.list()
                         .stream()
-                        .map(uiElement -> uiElement.expect().text().getActual())
+                        .map(uiElement -> uiElement.waitFor().text().getActual())
                         .map(String::toUpperCase)
                         .allMatch(i -> i.contains(expectedText.toUpperCase()))) {
                     allLogLinesMarkedAsExpected = false;
@@ -87,7 +87,7 @@ public class ReportLogsPage extends AbstractReportPage {
 
         boolean allLogLinesMarkedAsExpected = list
                 .stream()
-                .map(uiElement -> uiElement.expect().text().getActual())
+                .map(uiElement -> uiElement.waitFor().text().getActual())
                 .map(String::toUpperCase)
                 .allMatch(i -> i.contains(expectedText.toUpperCase()));
 

--- a/report-ng-tests/src/main/java/io/testerra/report/test/pages/report/sideBarPages/ReportTestsPage.java
+++ b/report-ng-tests/src/main/java/io/testerra/report/test/pages/report/sideBarPages/ReportTestsPage.java
@@ -28,9 +28,7 @@ import eu.tsystems.mms.tic.testframework.report.Status;
 import io.testerra.report.test.pages.AbstractReportPage;
 import io.testerra.report.test.pages.ReportSidebarPageType;
 import io.testerra.report.test.pages.report.methodReport.AbstractReportMethodPage;
-import io.testerra.report.test.pages.report.methodReport.ReportDependenciesTab;
 import io.testerra.report.test.pages.report.methodReport.ReportDetailsTab;
-import io.testerra.report.test.pages.report.methodReport.ReportSessionsTab;
 import io.testerra.report.test.pages.report.methodReport.ReportStepsTab;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
@@ -238,15 +236,6 @@ public class ReportTestsPage extends AbstractReportPage {
         return createPage(ReportStepsTab.class);
     }
 
-    public ReportSessionsTab navigateToSessionsTab(final String methodName, final Status status) {
-
-        final String methodNameLinkLocator = tableRowsLocator.concat("[.//a[text()= '" + status.title + "']]//a[text()= '" + methodName + "']");
-        final UiElement methodNameLink = find(By.xpath(methodNameLinkLocator));
-        methodNameLink.click();
-
-        return createPage(ReportSessionsTab.class);
-    }
-
     public ReportDetailsTab navigateToDetailsTab(final String methodName, final Status status) {
 
         final String methodNameLinkLocator = tableRowsLocator.concat("[.//a[text()= '" + status.title + "']]//a[text()= '" + methodName + "']");
@@ -254,15 +243,6 @@ public class ReportTestsPage extends AbstractReportPage {
         methodNameLink.click();
 
         return createPage(ReportDetailsTab.class);
-    }
-
-    public ReportDependenciesTab navigateToDependenciesTab(final String methodName, final Status status) {
-
-        final String methodNameLinkLocator = tableRowsLocator.concat("[.//a[text()= '" + status.title + "']]//a[text()= '" + methodName + "']");
-        final UiElement methodNameLink = find(By.xpath(methodNameLinkLocator));
-        methodNameLink.click();
-
-        return createPage(ReportDependenciesTab.class);
     }
 
     public <T extends AbstractReportMethodPage> T navigateToMethodDetails(final Class<T> reportPageClass, String methodName) {

--- a/report-ng-tests/src/main/java/io/testerra/report/test/pages/report/sideBarPages/ReportTestsPage.java
+++ b/report-ng-tests/src/main/java/io/testerra/report/test/pages/report/sideBarPages/ReportTestsPage.java
@@ -93,19 +93,15 @@ public class ReportTestsPage extends AbstractReportPage {
         }
     }
 
-
     public ReportTestsPage(WebDriver driver) {
         super(driver);
     }
 
-    public List<UiElement> getColumnWithoutHead(int columnNumber) {
+    private List<UiElement> getColumnWithoutHead(final int columnNumber) {
         List<UiElement> column = new ArrayList<>();
-        for (UiElement row : tableRows.list().stream().collect(Collectors.toList())) {
-            column.add(row.find(By.xpath("//td")).list().stream().collect(Collectors.toList()).get(columnNumber));
-        }
+        tableRows.list().forEach(row -> column.add(row.find(By.xpath("//td[" + (columnNumber + 1) + "]"))));
         return column;
     }
-
 
     public List<UiElement> getColumnWithoutHead(TestsTableEntry tableEntry) {
         return getColumnWithoutHead(tableEntry.index());
@@ -137,11 +133,17 @@ public class ReportTestsPage extends AbstractReportPage {
         verifyReportPage(ReportSidebarPageType.TESTS);
     }
 
-
-    public void assertMethodColumnContainsCorrectMethods(String filter) {
+    public void assertMethodColumnMatchesFilter(String filter) {
         getColumnWithoutHead(TestsTableEntry.METHOD)
                 .forEach(uiElement -> uiElement.expect().text().contains(filter).is(true,
                         String.format("Every found method [%s] should contain: %s", uiElement.expect().text().getActual(), filter)));
+    }
+
+    public void assertMethodColumnContainsCorrectMethods(List<String> methodNames) {
+        getColumnWithoutHead(TestsTableEntry.METHOD).forEach(uiElement -> {
+            String methodFromTable = uiElement.find(By.tagName("a")).waitFor().text().getActual();
+            Assert.assertTrue(methodNames.contains(methodFromTable), String.format("Testmethod %s should not shown with the given filter.", methodFromTable));
+        });
     }
 
     public void assertClassColumnContainsCorrectClasses(String expectedClass) {

--- a/report-ng-tests/src/main/java/io/testerra/report/test/pages/report/sideBarPages/ReportTestsPage.java
+++ b/report-ng-tests/src/main/java/io/testerra/report/test/pages/report/sideBarPages/ReportTestsPage.java
@@ -22,6 +22,7 @@
 package io.testerra.report.test.pages.report.sideBarPages;
 
 import eu.tsystems.mms.tic.testframework.pageobjects.Check;
+import eu.tsystems.mms.tic.testframework.pageobjects.PreparedLocator;
 import eu.tsystems.mms.tic.testframework.pageobjects.UiElement;
 import eu.tsystems.mms.tic.testframework.report.Status;
 import io.testerra.report.test.pages.AbstractReportPage;
@@ -54,7 +55,7 @@ public class ReportTestsPage extends AbstractReportPage {
     private final String tableRowsLocator = "//tbody//tr";
     private final UiElement tableRows = pageContent.find(By.xpath(tableRowsLocator));
 
-    private final String methodLinkLocator = "//tbody//tr//td//a[text()='%s']";
+    PreparedLocator preparedMethodLinkLocator = LOCATE.prepare("//a[contains(@route-href, 'method') and text()='%s']");
     private final UiElement tableHead = pageContent.find(By.xpath(".//thead"));
 
     public void checkPriorityMessagesPreviewForTest(String methodName, String[] priorityMessages) {
@@ -265,42 +266,24 @@ public class ReportTestsPage extends AbstractReportPage {
     }
 
     public <T extends AbstractReportMethodPage> T navigateToMethodDetails(final Class<T> reportPageClass, String methodName) {
-        UiElement subElement = pageContent.find(By.xpath(String.format(methodLinkLocator, methodName)));
+        UiElement subElement = pageContent.find(this.preparedMethodLinkLocator.with(methodName));
         subElement.click();
 
         return createPage(reportPageClass);
     }
 
     public ReportStepsTab navigateToStepsTab(String methodName) {
-
-        UiElement subElement = pageContent.find(By.xpath(String.format(methodLinkLocator, methodName)));
+        UiElement subElement = pageContent.find(this.preparedMethodLinkLocator.with(methodName));
         subElement.click();
 
         return createPage(ReportStepsTab.class);
     }
 
-    public ReportSessionsTab navigateToSessionsTab(String methodName) {
-
-        UiElement subElement = pageContent.find(By.xpath(String.format(methodLinkLocator, methodName)));
-        subElement.click();
-
-        return createPage(ReportSessionsTab.class);
-    }
-
     public ReportDetailsTab navigateToDetailsTab(String methodName) {
-
-        UiElement subElement = pageContent.find(By.xpath(String.format(methodLinkLocator, methodName)));
+        UiElement subElement = pageContent.find(this.preparedMethodLinkLocator.with(methodName));
         subElement.click();
 
         return createPage(ReportDetailsTab.class);
-    }
-
-    public ReportDependenciesTab navigateToDependenciesTab(String methodName) {
-
-        UiElement subElement = pageContent.find(By.xpath(String.format(methodLinkLocator, methodName)));
-        subElement.click();
-
-        return createPage(ReportDependenciesTab.class);
     }
 
     public ReportTestsPage clickConfigurationMethodsSwitch() {

--- a/report-ng-tests/src/test/java/io/testerra/report/test/AbstractReportTest.java
+++ b/report-ng-tests/src/test/java/io/testerra/report/test/AbstractReportTest.java
@@ -25,7 +25,6 @@ package io.testerra.report.test;
 import eu.tsystems.mms.tic.testframework.common.DefaultPropertyManager;
 import eu.tsystems.mms.tic.testframework.core.server.Server;
 import eu.tsystems.mms.tic.testframework.core.testpage.TestPage;
-import eu.tsystems.mms.tic.testframework.logging.Loggable;
 import eu.tsystems.mms.tic.testframework.report.Report;
 import eu.tsystems.mms.tic.testframework.utils.FileUtils;
 import io.testerra.report.test.pages.AbstractReportPage;
@@ -37,13 +36,10 @@ import org.testng.annotations.BeforeTest;
 import java.io.File;
 import java.net.BindException;
 
-import static eu.tsystems.mms.tic.testframework.testing.PageFactoryProvider.PAGE_FACTORY;
-import static eu.tsystems.mms.tic.testframework.testing.WebDriverManagerProvider.WEB_DRIVER_MANAGER;
-
 /**
  * Abstract test class for tests based on static test site resources
  */
-public abstract class AbstractReportTest extends AbstractTest implements Loggable {
+public abstract class AbstractReportTest extends AbstractTest {
 
     private final static File serverRootDir = FileUtils.getResourceFile("reports");
     private final static Server server = new Server(serverRootDir);

--- a/report-ng-tests/src/test/java/io/testerra/report/test/AbstractTest.java
+++ b/report-ng-tests/src/test/java/io/testerra/report/test/AbstractTest.java
@@ -1,15 +1,22 @@
 package io.testerra.report.test;
 
 import eu.tsystems.mms.tic.testframework.constants.Browsers;
+import eu.tsystems.mms.tic.testframework.logging.Loggable;
+import eu.tsystems.mms.tic.testframework.testing.AssertProvider;
+import eu.tsystems.mms.tic.testframework.testing.PageFactoryProvider;
 import eu.tsystems.mms.tic.testframework.testing.TesterraTest;
 import eu.tsystems.mms.tic.testframework.testing.WebDriverManagerProvider;
 import eu.tsystems.mms.tic.testframework.useragents.ChromeConfig;
 import org.testng.annotations.BeforeSuite;
 
-public abstract class AbstractTest extends TesterraTest {
+public abstract class AbstractTest extends TesterraTest implements
+        Loggable,
+        WebDriverManagerProvider,
+        PageFactoryProvider,
+        AssertProvider {
 
     @BeforeSuite(alwaysRun = true)
     public void configureChromeOptions() {
-        WebDriverManagerProvider.WEB_DRIVER_MANAGER.setUserAgentConfig(Browsers.chromeHeadless, (ChromeConfig) options -> options.addArguments("--disable-dev-shm-usage"));
+        WEB_DRIVER_MANAGER.setUserAgentConfig(Browsers.chromeHeadless, (ChromeConfig) options -> options.addArguments("--disable-dev-shm-usage"));
     }
 }

--- a/report-ng-tests/src/test/java/io/testerra/report/test/AbstractTestSitesTest.java
+++ b/report-ng-tests/src/test/java/io/testerra/report/test/AbstractTestSitesTest.java
@@ -24,6 +24,7 @@ package io.testerra.report.test;
 
 import eu.tsystems.mms.tic.testframework.core.server.Server;
 import eu.tsystems.mms.tic.testframework.logging.Loggable;
+import eu.tsystems.mms.tic.testframework.testing.AssertProvider;
 import eu.tsystems.mms.tic.testframework.testing.PageFactoryProvider;
 import eu.tsystems.mms.tic.testframework.testing.WebDriverManagerProvider;
 import eu.tsystems.mms.tic.testframework.utils.FileUtils;
@@ -37,7 +38,7 @@ import java.net.BindException;
 /**
  * Abstract test class for tests based on static test site resources
  */
-public abstract class AbstractTestSitesTest extends AbstractTest implements WebDriverManagerProvider, PageFactoryProvider, Loggable {
+public abstract class AbstractTestSitesTest extends AbstractTest implements WebDriverManagerProvider, PageFactoryProvider, AssertProvider, Loggable {
 
     protected static Server server = new Server(FileUtils.getResourceFile("testsites"));
     private String exclusiveSessionId;

--- a/report-ng-tests/src/test/java/io/testerra/report/test/TestDataProvider.java
+++ b/report-ng-tests/src/test/java/io/testerra/report/test/TestDataProvider.java
@@ -111,10 +111,10 @@ public class TestDataProvider {
         };
     }
 
-    @DataProvider(parallel = true)
+    @DataProvider(parallel = false)
     public static Object[][] dataProviderForPreTestMethodsWithStatusFailed() {
         return new Object[][]{
-                {new TestData("testAssertCollector", "AssertCollector.fail", "AssertCollector.fail")},
+                {new TestData("testAssertCollector", "ASSERT.fail(\"failed1\")", "ASSERT.fail(\"failed2\")")},
                 {new TestData("test_failedPageNotFound", "PAGE_FACTORY.createPage(NonExistingPage.class, WEB_DRIVER_MANAGER.getWebDriver());")},
                 {new TestData("test_Failed", "Assert.fail")},
                 {new TestData("test_Failed_WithScreenShot", "Assert.fail")}

--- a/report-ng-tests/src/test/java/io/testerra/report/test/pretest_status/classContext/GenerateClassContextChildClassTest.java
+++ b/report-ng-tests/src/test/java/io/testerra/report/test/pretest_status/classContext/GenerateClassContextChildClassTest.java
@@ -13,7 +13,6 @@ public class GenerateClassContextChildClassTest extends GenerateClassContextPare
 
     @Test
     public void testTestMethodInChildClasses() {
-
     }
 
 }

--- a/report-ng-tests/src/test/java/io/testerra/report/test/pretest_status/classContext/GenerateClassContextChildClassTest.java
+++ b/report-ng-tests/src/test/java/io/testerra/report/test/pretest_status/classContext/GenerateClassContextChildClassTest.java
@@ -1,3 +1,23 @@
+/*
+ * Testerra
+ *
+ * (C) 2023, Martin Großmann, Telekom MMS GmbH, Deutsche Telekom AG
+ *
+ * Deutsche Telekom AG and all other contributors /
+ * copyright owners license this file to you under the Apache
+ * License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package io.testerra.report.test.pretest_status.classContext;
 
 import eu.tsystems.mms.tic.testframework.annotations.TestClassContext;

--- a/report-ng-tests/src/test/java/io/testerra/report/test/pretest_status/classContext/GenerateClassContextChildClassTest.java
+++ b/report-ng-tests/src/test/java/io/testerra/report/test/pretest_status/classContext/GenerateClassContextChildClassTest.java
@@ -1,0 +1,19 @@
+package io.testerra.report.test.pretest_status.classContext;
+
+import eu.tsystems.mms.tic.testframework.annotations.TestClassContext;
+import org.testng.annotations.Test;
+
+/**
+ * Created on 2023-03-21
+ *
+ * @author mgn
+ */
+@TestClassContext(name = "ClassContextInheritedClasses")
+public class GenerateClassContextChildClassTest extends GenerateClassContextParentClassTest {
+
+    @Test
+    public void testTestMethodInChildClasses() {
+
+    }
+
+}

--- a/report-ng-tests/src/test/java/io/testerra/report/test/pretest_status/classContext/GenerateClassContextDifferentNames1Test.java
+++ b/report-ng-tests/src/test/java/io/testerra/report/test/pretest_status/classContext/GenerateClassContextDifferentNames1Test.java
@@ -1,0 +1,20 @@
+package io.testerra.report.test.pretest_status.classContext;
+
+import eu.tsystems.mms.tic.testframework.annotations.TestClassContext;
+import io.testerra.report.test.AbstractTestSitesTest;
+import org.testng.annotations.Test;
+
+/**
+ * Created on 2023-03-21
+ *
+ * @author mgn
+ */
+@TestClassContext(name = "ClassContextDifferentClasses")
+public class GenerateClassContextDifferentNames1Test extends AbstractTestSitesTest {
+
+    @Test
+    public void testTestMethodInDifferentClasses1() {
+
+    }
+
+}

--- a/report-ng-tests/src/test/java/io/testerra/report/test/pretest_status/classContext/GenerateClassContextDifferentNames1Test.java
+++ b/report-ng-tests/src/test/java/io/testerra/report/test/pretest_status/classContext/GenerateClassContextDifferentNames1Test.java
@@ -1,3 +1,23 @@
+/*
+ * Testerra
+ *
+ * (C) 2023, Martin Großmann, Telekom MMS GmbH, Deutsche Telekom AG
+ *
+ * Deutsche Telekom AG and all other contributors /
+ * copyright owners license this file to you under the Apache
+ * License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package io.testerra.report.test.pretest_status.classContext;
 
 import eu.tsystems.mms.tic.testframework.annotations.TestClassContext;

--- a/report-ng-tests/src/test/java/io/testerra/report/test/pretest_status/classContext/GenerateClassContextDifferentNames1Test.java
+++ b/report-ng-tests/src/test/java/io/testerra/report/test/pretest_status/classContext/GenerateClassContextDifferentNames1Test.java
@@ -14,7 +14,6 @@ public class GenerateClassContextDifferentNames1Test extends AbstractTestSitesTe
 
     @Test
     public void testTestMethodInDifferentClasses1() {
-
     }
 
 }

--- a/report-ng-tests/src/test/java/io/testerra/report/test/pretest_status/classContext/GenerateClassContextDifferentNames2Test.java
+++ b/report-ng-tests/src/test/java/io/testerra/report/test/pretest_status/classContext/GenerateClassContextDifferentNames2Test.java
@@ -14,7 +14,6 @@ public class GenerateClassContextDifferentNames2Test extends AbstractTestSitesTe
 
     @Test
     public void testTestMethodInDifferentClasses2() {
-
     }
 
 }

--- a/report-ng-tests/src/test/java/io/testerra/report/test/pretest_status/classContext/GenerateClassContextDifferentNames2Test.java
+++ b/report-ng-tests/src/test/java/io/testerra/report/test/pretest_status/classContext/GenerateClassContextDifferentNames2Test.java
@@ -1,0 +1,20 @@
+package io.testerra.report.test.pretest_status.classContext;
+
+import eu.tsystems.mms.tic.testframework.annotations.TestClassContext;
+import io.testerra.report.test.AbstractTestSitesTest;
+import org.testng.annotations.Test;
+
+/**
+ * Created on 2023-03-21
+ *
+ * @author mgn
+ */
+@TestClassContext(name = "ClassContextDifferentClasses")
+public class GenerateClassContextDifferentNames2Test extends AbstractTestSitesTest {
+
+    @Test
+    public void testTestMethodInDifferentClasses2() {
+
+    }
+
+}

--- a/report-ng-tests/src/test/java/io/testerra/report/test/pretest_status/classContext/GenerateClassContextDifferentNames2Test.java
+++ b/report-ng-tests/src/test/java/io/testerra/report/test/pretest_status/classContext/GenerateClassContextDifferentNames2Test.java
@@ -1,3 +1,23 @@
+/*
+ * Testerra
+ *
+ * (C) 2023, Martin Großmann, Telekom MMS GmbH, Deutsche Telekom AG
+ *
+ * Deutsche Telekom AG and all other contributors /
+ * copyright owners license this file to you under the Apache
+ * License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package io.testerra.report.test.pretest_status.classContext;
 
 import eu.tsystems.mms.tic.testframework.annotations.TestClassContext;

--- a/report-ng-tests/src/test/java/io/testerra/report/test/pretest_status/classContext/GenerateClassContextParentClassTest.java
+++ b/report-ng-tests/src/test/java/io/testerra/report/test/pretest_status/classContext/GenerateClassContextParentClassTest.java
@@ -14,7 +14,6 @@ public class GenerateClassContextParentClassTest extends AbstractTestSitesTest {
 
     @Test
     public void testTestMethodInParentClasses() {
-
     }
 
 }

--- a/report-ng-tests/src/test/java/io/testerra/report/test/pretest_status/classContext/GenerateClassContextParentClassTest.java
+++ b/report-ng-tests/src/test/java/io/testerra/report/test/pretest_status/classContext/GenerateClassContextParentClassTest.java
@@ -1,0 +1,20 @@
+package io.testerra.report.test.pretest_status.classContext;
+
+import eu.tsystems.mms.tic.testframework.annotations.TestClassContext;
+import io.testerra.report.test.AbstractTestSitesTest;
+import org.testng.annotations.Test;
+
+/**
+ * Created on 2023-03-21
+ *
+ * @author mgn
+ */
+@TestClassContext(name = "ClassContextInheritedClasses")
+public class GenerateClassContextParentClassTest extends AbstractTestSitesTest {
+
+    @Test
+    public void testTestMethodInParentClasses() {
+
+    }
+
+}

--- a/report-ng-tests/src/test/java/io/testerra/report/test/pretest_status/classContext/GenerateClassContextParentClassTest.java
+++ b/report-ng-tests/src/test/java/io/testerra/report/test/pretest_status/classContext/GenerateClassContextParentClassTest.java
@@ -1,3 +1,23 @@
+/*
+ * Testerra
+ *
+ * (C) 2023, Martin Großmann, Telekom MMS GmbH, Deutsche Telekom AG
+ *
+ * Deutsche Telekom AG and all other contributors /
+ * copyright owners license this file to you under the Apache
+ * License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package io.testerra.report.test.pretest_status.classContext;
 
 import eu.tsystems.mms.tic.testframework.annotations.TestClassContext;

--- a/report-ng-tests/src/test/java/io/testerra/report/test/pretest_status/classContext/pack1/GenerateClassContextSameNameTest.java
+++ b/report-ng-tests/src/test/java/io/testerra/report/test/pretest_status/classContext/pack1/GenerateClassContextSameNameTest.java
@@ -11,7 +11,9 @@ import org.testng.annotations.Test;
  */
 @TestClassContext(name = "ClassContextSameClassPack1")
 public class GenerateClassContextSameNameTest extends AbstractTestSitesTest {
+
     @Test
     public void testTestMethodInSameClassesPack1() {
     }
+
 }

--- a/report-ng-tests/src/test/java/io/testerra/report/test/pretest_status/classContext/pack1/GenerateClassContextSameNameTest.java
+++ b/report-ng-tests/src/test/java/io/testerra/report/test/pretest_status/classContext/pack1/GenerateClassContextSameNameTest.java
@@ -9,7 +9,7 @@ import org.testng.annotations.Test;
  *
  * @author mgn
  */
-//@TestClassContext(name = "ClassContextSameClassPack1")
+@TestClassContext(name = "ClassContextSameClassPack1")
 public class GenerateClassContextSameNameTest extends AbstractTestSitesTest {
     @Test
     public void testTestMethodInSameClassesPack1() {

--- a/report-ng-tests/src/test/java/io/testerra/report/test/pretest_status/classContext/pack1/GenerateClassContextSameNameTest.java
+++ b/report-ng-tests/src/test/java/io/testerra/report/test/pretest_status/classContext/pack1/GenerateClassContextSameNameTest.java
@@ -1,0 +1,17 @@
+package io.testerra.report.test.pretest_status.classContext.pack1;
+
+import eu.tsystems.mms.tic.testframework.annotations.TestClassContext;
+import io.testerra.report.test.AbstractTestSitesTest;
+import org.testng.annotations.Test;
+
+/**
+ * Created on 2023-03-22
+ *
+ * @author mgn
+ */
+//@TestClassContext(name = "ClassContextSameClassPack1")
+public class GenerateClassContextSameNameTest extends AbstractTestSitesTest {
+    @Test
+    public void testTestMethodInSameClassesPack1() {
+    }
+}

--- a/report-ng-tests/src/test/java/io/testerra/report/test/pretest_status/classContext/pack1/GenerateClassContextSameNameTest.java
+++ b/report-ng-tests/src/test/java/io/testerra/report/test/pretest_status/classContext/pack1/GenerateClassContextSameNameTest.java
@@ -1,3 +1,23 @@
+/*
+ * Testerra
+ *
+ * (C) 2023, Martin Großmann, Telekom MMS GmbH, Deutsche Telekom AG
+ *
+ * Deutsche Telekom AG and all other contributors /
+ * copyright owners license this file to you under the Apache
+ * License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package io.testerra.report.test.pretest_status.classContext.pack1;
 
 import eu.tsystems.mms.tic.testframework.annotations.TestClassContext;

--- a/report-ng-tests/src/test/java/io/testerra/report/test/pretest_status/classContext/pack2/GenerateClassContextSameNameTest.java
+++ b/report-ng-tests/src/test/java/io/testerra/report/test/pretest_status/classContext/pack2/GenerateClassContextSameNameTest.java
@@ -1,0 +1,18 @@
+package io.testerra.report.test.pretest_status.classContext.pack2;
+
+import io.testerra.report.test.AbstractTestSitesTest;
+import org.testng.annotations.Test;
+
+/**
+ * Created on 2023-03-22
+ *
+ * @author mgn
+ */
+//@TestClassContext(name = "ClassContextSameClassPack2")
+public class GenerateClassContextSameNameTest extends AbstractTestSitesTest {
+
+    @Test
+    public void testTestMethodInSameClassesPack2() {
+    }
+
+}

--- a/report-ng-tests/src/test/java/io/testerra/report/test/pretest_status/classContext/pack2/GenerateClassContextSameNameTest.java
+++ b/report-ng-tests/src/test/java/io/testerra/report/test/pretest_status/classContext/pack2/GenerateClassContextSameNameTest.java
@@ -1,5 +1,6 @@
 package io.testerra.report.test.pretest_status.classContext.pack2;
 
+import eu.tsystems.mms.tic.testframework.annotations.TestClassContext;
 import io.testerra.report.test.AbstractTestSitesTest;
 import org.testng.annotations.Test;
 
@@ -8,7 +9,7 @@ import org.testng.annotations.Test;
  *
  * @author mgn
  */
-//@TestClassContext(name = "ClassContextSameClassPack2")
+@TestClassContext(name = "ClassContextSameClassPack2")
 public class GenerateClassContextSameNameTest extends AbstractTestSitesTest {
 
     @Test

--- a/report-ng-tests/src/test/java/io/testerra/report/test/pretest_status/classContext/pack2/GenerateClassContextSameNameTest.java
+++ b/report-ng-tests/src/test/java/io/testerra/report/test/pretest_status/classContext/pack2/GenerateClassContextSameNameTest.java
@@ -1,3 +1,23 @@
+/*
+ * Testerra
+ *
+ * (C) 2023, Martin Großmann, Telekom MMS GmbH, Deutsche Telekom AG
+ *
+ * Deutsche Telekom AG and all other contributors /
+ * copyright owners license this file to you under the Apache
+ * License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package io.testerra.report.test.pretest_status.classContext.pack2;
 
 import eu.tsystems.mms.tic.testframework.annotations.TestClassContext;

--- a/report-ng-tests/src/test/java/io/testerra/report/test/pretest_status/expected/failed/GenerateExpectedFailedStatusInTesterraReportTest.java
+++ b/report-ng-tests/src/test/java/io/testerra/report/test/pretest_status/expected/failed/GenerateExpectedFailedStatusInTesterraReportTest.java
@@ -22,28 +22,26 @@
 package io.testerra.report.test.pretest_status.expected.failed;
 
 import eu.tsystems.mms.tic.testframework.annotations.Fails;
+import eu.tsystems.mms.tic.testframework.annotations.TestClassContext;
 import eu.tsystems.mms.tic.testframework.report.model.context.MethodContext;
-import eu.tsystems.mms.tic.testframework.testing.AssertProvider;
-
-import java.util.concurrent.atomic.AtomicInteger;
-
+import io.testerra.report.test.AbstractTestSitesTest;
+import io.testerra.report.test.pages.pretest.NonExistingPage;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import io.testerra.report.test.AbstractTestSitesTest;
-import io.testerra.report.test.pages.pretest.NonExistingPage;
+import java.util.concurrent.atomic.AtomicInteger;
 
-public class GenerateExpectedFailedStatusInTesterraReportTest extends AbstractTestSitesTest implements AssertProvider {
+public class GenerateExpectedFailedStatusInTesterraReportTest extends AbstractTestSitesTest {
 
     final AtomicInteger counter = new AtomicInteger(0);
 
-//    repaired
+    // repaired
     @Test
     @Fails(description = "not failing anymore")
     public void test_expectedFailedPassed() {
     }
 
-//    recovered
+    // recovered
     @Test()
     public void test_PassedAfterRetry() {
         this.counter.incrementAndGet();
@@ -54,7 +52,7 @@ public class GenerateExpectedFailedStatusInTesterraReportTest extends AbstractTe
         }
     }
 
-//    expected failed
+    // expected failed
     @Test
     @Fails(description = "failing expected")
     public void test_expectedFailed() {
@@ -65,9 +63,9 @@ public class GenerateExpectedFailedStatusInTesterraReportTest extends AbstractTe
     @Fails(description = "collected assert failing")
     public void test_expectedFailedAssertCollector() {
         CONTROL.collectAssertions(() -> {
-                    ASSERT.fail("failed1");
-                    ASSERT.fail("failed2");
-                    ASSERT.assertTrue(true, "passed1");
+            ASSERT.fail("failed1");
+            ASSERT.fail("failed2");
+            ASSERT.assertTrue(true, "passed1");
         });
     }
 
@@ -91,19 +89,19 @@ public class GenerateExpectedFailedStatusInTesterraReportTest extends AbstractTe
 
     @Test
     @Fails(validator = "expectedFailIsValid")
-    public void test_expectedFailedWithValidator_isValid(){
+    public void test_expectedFailedWithValidator_isValid() {
         Assert.fail("Expected Fail - validator is: " + expectedFailIsValid(null));
     }
 
     @Test
     @Fails(validator = "expectedFailIsNotValid")
-    public void test_expectedFailedWithValidator_isNotValid(){
+    public void test_expectedFailedWithValidator_isNotValid() {
         Assert.fail("Expected Fail - validator is: " + expectedFailIsNotValid(null));
     }
 
     @Test
     @Fails(ticketString = "placeholder ticket string")
-    public void test_expectedFailedWithTicketString(){
+    public void test_expectedFailedWithTicketString() {
         Assert.fail("Expected fail with ticket string");
     }
 }

--- a/report-ng-tests/src/test/java/io/testerra/report/test/pretest_status/simple/GenerateFailedStatusInTesterraReportTest.java
+++ b/report-ng-tests/src/test/java/io/testerra/report/test/pretest_status/simple/GenerateFailedStatusInTesterraReportTest.java
@@ -21,15 +21,12 @@
 
 package io.testerra.report.test.pretest_status.simple;
 
-import eu.tsystems.mms.tic.testframework.execution.testng.AssertCollector;
 import eu.tsystems.mms.tic.testframework.report.FailureCorridor;
 import eu.tsystems.mms.tic.testframework.report.model.steps.TestStep;
-
 import io.testerra.report.test.AbstractTestSitesTest;
 import io.testerra.report.test.pages.TestPage;
 import io.testerra.report.test.pages.pretest.NonExistingPage;
 import io.testerra.report.test.pages.pretest.OverlayInterceptionPage;
-
 import org.openqa.selenium.WebDriver;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -44,9 +41,12 @@ public class GenerateFailedStatusInTesterraReportTest extends AbstractTestSitesT
 
     @Test
     public void testAssertCollector() {
-        AssertCollector.fail("failed1");
-        AssertCollector.fail("failed2");
-        AssertCollector.assertTrue(true, "passed1");
+        CONTROL.optionalAssertions(() -> {
+            ASSERT.fail("failed1");
+            ASSERT.fail("failed2");
+            ASSERT.assertTrue(true, "passed1");
+        });
+
     }
 
     @Test

--- a/report-ng-tests/src/test/java/io/testerra/report/test/pretest_status/simple/GenerateFailedStatusInTesterraReportTest.java
+++ b/report-ng-tests/src/test/java/io/testerra/report/test/pretest_status/simple/GenerateFailedStatusInTesterraReportTest.java
@@ -41,12 +41,11 @@ public class GenerateFailedStatusInTesterraReportTest extends AbstractTestSitesT
 
     @Test
     public void testAssertCollector() {
-        CONTROL.optionalAssertions(() -> {
+        CONTROL.collectAssertions(() -> {
             ASSERT.fail("failed1");
             ASSERT.fail("failed2");
             ASSERT.assertTrue(true, "passed1");
         });
-
     }
 
     @Test

--- a/report-ng-tests/src/test/java/io/testerra/report/test/report_test/extensions/CheckRuleTest.java
+++ b/report-ng-tests/src/test/java/io/testerra/report/test/report_test/extensions/CheckRuleTest.java
@@ -1,4 +1,4 @@
-package io.testerra.report.test.report_test.TT2_extensions;
+package io.testerra.report.test.report_test.extensions;
 
 import eu.tsystems.mms.tic.testframework.report.Status;
 import eu.tsystems.mms.tic.testframework.report.model.steps.TestStep;

--- a/report-ng-tests/src/test/java/io/testerra/report/test/report_test/extensions/ClassContextTest.java
+++ b/report-ng-tests/src/test/java/io/testerra/report/test/report_test/extensions/ClassContextTest.java
@@ -1,0 +1,61 @@
+package io.testerra.report.test.report_test.extensions;
+
+import eu.tsystems.mms.tic.testframework.report.model.steps.TestStep;
+import io.testerra.report.test.AbstractReportTest;
+import io.testerra.report.test.pages.ReportSidebarPageType;
+import io.testerra.report.test.pages.report.sideBarPages.ReportDashBoardPage;
+import io.testerra.report.test.pages.report.sideBarPages.ReportTestsPage;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Created on 2023-03-23
+ *
+ * @author mgn
+ */
+public class ClassContextTest extends AbstractReportTest {
+
+    @DataProvider(name = "classContextProvider")
+    public Iterator<TestContainer> classContextProvider() {
+        List<TestContainer> classContexts = new ArrayList<>();
+
+        classContexts.add(new TestContainer("ClassContextInheritedClasses", 3, List.of("testTestMethodInChildClasses", "testTestMethodInParentClasses")));
+        classContexts.add(new TestContainer("ClassContextDifferentClasses", 2, List.of("testTestMethodInDifferentClasses1", "testTestMethodInDifferentClasses2")));
+        classContexts.add(new TestContainer("ClassContextSameClassPack1", 1, List.of("testTestMethodInSameClassesPack1")));
+        classContexts.add(new TestContainer("ClassContextSameClassPack2", 1, List.of("testTestMethodInSameClassesPack2")));
+
+        return classContexts.iterator();
+    }
+
+    @Test(dataProvider = "classContextProvider")
+    public void testT01_classContextClassesView(TestContainer testContainer) {
+//        String classContextName = "ClassContextInheritedClasses";
+//        int countMethods = 3;
+//        List<String> methods = List.of("testTestMethodInChildClasses", "testTestMethodInParentClasses");
+
+        TestStep.begin("Navigate to tests page.");
+        ReportDashBoardPage reportDashBoardPage = this.gotoDashBoardOnAdditionalReport();
+        ReportTestsPage reportTestsPage = reportDashBoardPage.gotoToReportPage(ReportSidebarPageType.TESTS, ReportTestsPage.class);
+
+        reportTestsPage = reportTestsPage.selectClassName(testContainer.classContextName);
+        ASSERT.assertEquals(reportTestsPage.getColumnWithoutHead(ReportTestsPage.TestsTableEntry.METHOD).size(), testContainer.countMethods);
+        reportTestsPage.assertMethodColumnContainsCorrectMethods(testContainer.methods);
+    }
+
+    class TestContainer {
+        public String classContextName;
+        public int countMethods;
+        public List<String> methods;
+
+        public TestContainer(String classContextName, int countMethods, List<String> methods) {
+            this.classContextName = classContextName;
+            this.countMethods = countMethods;
+            this.methods = methods;
+        }
+    }
+
+}

--- a/report-ng-tests/src/test/java/io/testerra/report/test/report_test/extensions/DetailsTabExtensionsTest.java
+++ b/report-ng-tests/src/test/java/io/testerra/report/test/report_test/extensions/DetailsTabExtensionsTest.java
@@ -1,4 +1,4 @@
-package io.testerra.report.test.report_test.TT2_extensions;
+package io.testerra.report.test.report_test.extensions;
 
 import eu.tsystems.mms.tic.testframework.report.model.steps.TestStep;
 import io.testerra.report.test.AbstractReportTest;

--- a/report-ng-tests/src/test/java/io/testerra/report/test/report_test/extensions/ExclusiveSessionsTest.java
+++ b/report-ng-tests/src/test/java/io/testerra/report/test/report_test/extensions/ExclusiveSessionsTest.java
@@ -1,4 +1,4 @@
-package io.testerra.report.test.report_test.TT2_extensions;
+package io.testerra.report.test.report_test.extensions;
 
 import eu.tsystems.mms.tic.testframework.report.model.steps.TestStep;
 import io.testerra.report.test.AbstractReportTest;

--- a/report-ng-tests/src/test/java/io/testerra/report/test/report_test/extensions/LayoutTest.java
+++ b/report-ng-tests/src/test/java/io/testerra/report/test/report_test/extensions/LayoutTest.java
@@ -1,4 +1,4 @@
-package io.testerra.report.test.report_test.TT2_extensions;
+package io.testerra.report.test.report_test.extensions;
 
 import eu.tsystems.mms.tic.testframework.report.Status;
 import eu.tsystems.mms.tic.testframework.report.model.steps.TestStep;

--- a/report-ng-tests/src/test/java/io/testerra/report/test/report_test/extensions/PriorityMessagesTest.java
+++ b/report-ng-tests/src/test/java/io/testerra/report/test/report_test/extensions/PriorityMessagesTest.java
@@ -1,4 +1,4 @@
-package io.testerra.report.test.report_test.TT2_extensions;
+package io.testerra.report.test.report_test.extensions;
 
 import eu.tsystems.mms.tic.testframework.common.DefaultPropertyManager;
 import eu.tsystems.mms.tic.testframework.report.model.steps.TestStep;

--- a/report-ng-tests/src/test/java/io/testerra/report/test/report_test/extensions/TestStepsTest.java
+++ b/report-ng-tests/src/test/java/io/testerra/report/test/report_test/extensions/TestStepsTest.java
@@ -1,4 +1,4 @@
-package io.testerra.report.test.report_test.TT2_extensions;
+package io.testerra.report.test.report_test.extensions;
 
 import eu.tsystems.mms.tic.testframework.common.DefaultPropertyManager;
 import eu.tsystems.mms.tic.testframework.report.model.steps.TestStep;

--- a/report-ng-tests/src/test/java/io/testerra/report/test/report_test/extensions/TicketStringsTest.java
+++ b/report-ng-tests/src/test/java/io/testerra/report/test/report_test/extensions/TicketStringsTest.java
@@ -1,4 +1,4 @@
-package io.testerra.report.test.report_test.TT2_extensions;
+package io.testerra.report.test.report_test.extensions;
 
 import eu.tsystems.mms.tic.testframework.common.DefaultPropertyManager;
 import eu.tsystems.mms.tic.testframework.report.model.steps.TestStep;

--- a/report-ng-tests/src/test/java/io/testerra/report/test/report_test/extensions/ValidatorTest.java
+++ b/report-ng-tests/src/test/java/io/testerra/report/test/report_test/extensions/ValidatorTest.java
@@ -1,4 +1,4 @@
-package io.testerra.report.test.report_test.TT2_extensions;
+package io.testerra.report.test.report_test.extensions;
 
 import eu.tsystems.mms.tic.testframework.report.Status;
 import eu.tsystems.mms.tic.testframework.report.model.steps.TestStep;

--- a/report-ng-tests/src/test/java/io/testerra/report/test/report_test/sidebarpages/ReportFailureAspectsPageTest.java
+++ b/report-ng-tests/src/test/java/io/testerra/report/test/report_test/sidebarpages/ReportFailureAspectsPageTest.java
@@ -32,13 +32,10 @@ import io.testerra.report.test.pages.report.sideBarPages.ReportFailureAspectsPag
 import io.testerra.report.test.pages.report.sideBarPages.ReportTestsPage;
 import io.testerra.report.test.pages.utils.FailureAspectType;
 import io.testerra.report.test.pages.utils.TestData;
-import org.openqa.selenium.WebDriver;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.util.List;
-
-import static eu.tsystems.mms.tic.testframework.testing.WebDriverManagerProvider.WEB_DRIVER_MANAGER;
 
 public class ReportFailureAspectsPageTest extends AbstractReportTest {
 
@@ -147,6 +144,6 @@ public class ReportFailureAspectsPageTest extends AbstractReportTest {
 
         TestStep.begin("Check every status for failure aspect links to tests-page with content");
         ReportTestsPage reportTestsPage = reportFailureAspectsPage.clickStateLink(failureAspect, status);
-        reportTestsPage.assertMethodColumnContainsCorrectMethods(methodName);
+        reportTestsPage.assertMethodColumnMatchesFilter(methodName);
     }
 }

--- a/report-ng-tests/src/test/java/io/testerra/report/test/report_test/sidebarpages/ReportLogsPageTest.java
+++ b/report-ng-tests/src/test/java/io/testerra/report/test/report_test/sidebarpages/ReportLogsPageTest.java
@@ -105,7 +105,7 @@ public class ReportLogsPageTest extends AbstractReportTest {
      * Basic LogPageTest doing filter and one search and check marked line without any scrolling
      * can be replaced when scrolling is robust
      */
-    @Test()
+    @Test(enabled = false, description = "Issue in log view with Filter=INFO and Search=Failed -> View is shaking...")
     public void testT04_filterForMethodContentWithLogLevelBasic() {
         final String methodeName = "testAssertCollector";
         final String methodeClass = "GeneratePassedStatusInTesterraReportTest";
@@ -118,8 +118,7 @@ public class ReportLogsPageTest extends AbstractReportTest {
         ReportLogsPage reportLogsPage = reportDashBoardPage.gotoToReportPage(ReportSidebarPageType.LOGS, ReportLogsPage.class);
 
         for (final LogLevel logLevel : LogLevel.values()) {
-
-            TestStep.begin("Check whether the logLevel-select works correctly");
+            TestStep.begin("Check whether the logLevel-select works correctly: " + logLevel);
             reportLogsPage = reportLogsPage.selectLogLevel(logLevel);
             reportLogsPage.assertLogReportContainsCorrectLogLevel(logLevel);
 

--- a/report-ng-tests/src/test/java/io/testerra/report/test/report_test/sidebarpages/ReportTestsPageTest.java
+++ b/report-ng-tests/src/test/java/io/testerra/report/test/report_test/sidebarpages/ReportTestsPageTest.java
@@ -74,7 +74,7 @@ public class ReportTestsPageTest extends AbstractReportTest {
 
         TestStep.begin("Check whether method-column contains correct methods");
         reportTestsPage = reportTestsPage.search(testMethod);
-        reportTestsPage.assertMethodColumnContainsCorrectMethods(testMethod);
+        reportTestsPage.assertMethodColumnMatchesFilter(testMethod);
         reportTestsPage.assertMethodeColumnHeadlineContainsCorrectText();
     }
 
@@ -88,7 +88,7 @@ public class ReportTestsPageTest extends AbstractReportTest {
 
         TestStep.begin("Check whether method-column contains methods with correct failure aspects");
         reportTestsPage = reportTestsPage.search(failureAspect);
-        reportTestsPage.assertMethodColumnContainsCorrectMethods(failureAspect);
+        reportTestsPage.assertMethodColumnMatchesFilter(failureAspect);
         reportTestsPage.assertMethodeColumnHeadlineContainsCorrectText();
     }
 

--- a/report-ng-tests/src/test/resources/testng/GenerateExtendedReport.xml
+++ b/report-ng-tests/src/test/resources/testng/GenerateExtendedReport.xml
@@ -6,7 +6,6 @@
         <packages>
             <package name="io.testerra.report.test.pretest_status.pageTests"/>
             <package name="io.testerra.report.test.pretest_status.layoutTests"/>
-            <package name="io.testerra.report.test.pretest_status.classContext"/>
         </packages>
         <classes>
             <class name="io.testerra.report.test.pretest_status.expected.failed.GenerateExpectedFailedStatusInTesterraReportTest">
@@ -22,6 +21,12 @@
                 </methods>
             </class>
         </classes>
+    </test>
+
+    <test name="Parallel2" parallel="methods">
+        <packages>
+            <package name="io.testerra.report.test.pretest_status.classContext.*"/>
+        </packages>
     </test>
 
     <test name="Sequential">

--- a/report-ng-tests/src/test/resources/testng/GenerateExtendedReport.xml
+++ b/report-ng-tests/src/test/resources/testng/GenerateExtendedReport.xml
@@ -6,6 +6,7 @@
         <packages>
             <package name="io.testerra.report.test.pretest_status.pageTests"/>
             <package name="io.testerra.report.test.pretest_status.layoutTests"/>
+            <package name="io.testerra.report.test.pretest_status.classContext"/>
         </packages>
         <classes>
             <class name="io.testerra.report.test.pretest_status.expected.failed.GenerateExpectedFailedStatusInTesterraReportTest">

--- a/report-ng-tests/src/test/resources/testng/TestReport.xml
+++ b/report-ng-tests/src/test/resources/testng/TestReport.xml
@@ -5,7 +5,7 @@
         <packages>
             <package name="io.testerra.report.test.report_test.methodpages"/>
             <package name="io.testerra.report.test.report_test.sidebarpages"/>
-            <package name="io.testerra.report.test.report_test.TT2_extensions"/>
+            <package name="io.testerra.report.test.report_test.extensions"/>
         </packages>
     </test>
 </suite>

--- a/report-ng/app/src/components/classes/classes.html
+++ b/report-ng/app/src/components/classes/classes.html
@@ -51,7 +51,7 @@
                         <mdc-list-item>(All)</mdc-list-item>
                         <mdc-list-item value.bind="classStatistic.classIdentifier"
                                        repeat.for="classStatistic of _executionStatistics.classStatistics"
-                        >${classStatistic.classIdentifier}</mdc-list-item>
+                        >${classStatistic.classIdentifier|className:1}</mdc-list-item>
                     </mdc-list>
                 </mdc-select>
             </mdc-layout-grid-cell>
@@ -113,7 +113,7 @@
                             <td class="run-index-cell">${methodDetails.methodContext.methodRunIndex}</td>
                             <td class="p1 wrapable">
                                 <a route-href="route: tests; params.bind: withQueryParams({class: methodDetails.classStatistics.classIdentifier})"
-                                >${methodDetails.classStatistics.classIdentifier}</a>
+                                >${methodDetails.classStatistics.classIdentifier|className:1}</a>
                             </td>
                             <td class="p1 wrapable" mdc-body1>
 

--- a/report-ng/app/src/components/classes/classes.ts
+++ b/report-ng/app/src/components/classes/classes.ts
@@ -29,6 +29,7 @@ import {data} from "../../services/report-model";
 import {NavigationInstruction, RouteConfig} from "aurelia-router";
 import MethodType = data.MethodType;
 import "./classes.scss"
+import {ClassName, ClassNameValueConverter} from "../../value-converters/class-name-value-converter";
 
 enum SortBy {
     Class = "CLASS",
@@ -53,6 +54,7 @@ export class Classes extends AbstractViewModel {
         private _dataLoader: DataLoader,
         private _statusConverter: StatusConverter,
         private _statisticsGenerator: StatisticsGenerator,
+        private _classNameValueConverter: ClassNameValueConverter,
     ) {
         super();
     }
@@ -129,7 +131,11 @@ export class Classes extends AbstractViewModel {
                     return classStatistics;
                 })
                 .filter(classStatistic => {
-                    return !this.queryParams.class || this.queryParams.class == classStatistic.classIdentifier
+                    return !this.queryParams.class
+                        || (
+                            this.queryParams.class == this._classNameValueConverter.toView(classStatistic.classIdentifier, ClassName.simpleName)
+                            || this.queryParams.class == classStatistic.classIdentifier
+                            );
                 })
                 .forEach(classStatistic => {
                     let methodContexts = classStatistic.methodContexts;

--- a/report-ng/app/src/components/method-details/method.html
+++ b/report-ng/app/src/components/method-details/method.html
@@ -76,7 +76,8 @@
                             </li>
                             <li class="mdc-custom-list-item">
                                 <span class="secondary sr1">Package</span>
-                                <a class="two-lines">${_methodDetails.classStatistics.classIdentifier|className:2}</a>
+                                <span class="two-lines">${_methodDetails.classStatistics.classIdentifier|className:2}</span>
+                                <span class="two-lines" if.bind="_methodDetails.classStatistics.classIdentifier.indexOf('.')==-1">(Custom class context)</span>
                             </li>
                             <li class="mdc-custom-list-item">
                                 <span class="secondary sr1">Test Context</span>

--- a/report-ng/app/src/components/method-details/method.html
+++ b/report-ng/app/src/components/method-details/method.html
@@ -72,7 +72,11 @@
                                 <span class="secondary sr1">Class</span>
                                 <a class="two-lines"
                                    route-href="route: tests; params.bind: {class: _methodDetails.classStatistics.classIdentifier}"
-                                >${_methodDetails.classStatistics.classIdentifier}</a>
+                                >${_methodDetails.classStatistics.classIdentifier|className:1}</a>
+                            </li>
+                            <li class="mdc-custom-list-item">
+                                <span class="secondary sr1">Package</span>
+                                <a class="two-lines">${_methodDetails.classStatistics.classIdentifier|className:2}</a>
                             </li>
                             <li class="mdc-custom-list-item">
                                 <span class="secondary sr1">Test Context</span>

--- a/report-ng/app/src/components/test-classes-card/test-classes-card.ts
+++ b/report-ng/app/src/components/test-classes-card/test-classes-card.ts
@@ -26,6 +26,7 @@ import {StatisticsGenerator} from "../../services/statistics-generator";
 import {ClassStatistics} from "../../services/statistic-models";
 import {ApexOptions} from "apexcharts";
 import {bindingMode} from "aurelia-binding";
+import {ClassName, ClassNameValueConverter} from "../../value-converters/class-name-value-converter";
 import ResultStatusType = data.ResultStatusType;
 
 export interface IClassBarClickedDetails {
@@ -50,11 +51,13 @@ export class TestClassesCard {
     @bindable classStatistics: ClassStatistics[];
     private _apexBarOptions: ApexOptions = undefined;
     private _filteredStatuses: number[];
+    private _fullClassNames: string[] = [];
 
     constructor(
         private _statusConverter: StatusConverter,
         private _statisticsGenerator: StatisticsGenerator,
-        private _element: Element
+        private _element: Element,
+        private _classNameValueConverter: ClassNameValueConverter
     ) {
     }
 
@@ -71,6 +74,7 @@ export class TestClassesCard {
     private _prepareHorizontalBarChart(classStatistics: ClassStatistics[]): void {
         const data: Map<ResultStatusType, Array<number>> = new Map();
         const yLabels: string[] = [];
+        this._fullClassNames = [];
 
         const series = [];
         this._filteredStatuses = this._statusConverter.relevantStatuses.filter(status => (!this.filter?.status || status === this.filter.status));
@@ -106,8 +110,10 @@ export class TestClassesCard {
                     }
                 }
                 const className = classStats.classIdentifier;
-                //Push Class Names in array for y-axis labels
-                yLabels.push(className);
+                // Push simple class names in array for y-axis labels
+                yLabels.push(this._classNameValueConverter.toView(className, ClassName.simpleName));
+                // Push full class names incl. package for click event
+                this._fullClassNames.push(className);
             });
 
 
@@ -193,7 +199,8 @@ export class TestClassesCard {
         event?.stopPropagation();
 
         const filter: IFilter = {
-            class: this._apexBarOptions.xaxis.categories[config.dataPointIndex],
+            // class: this._apexBarOptions.xaxis.categories[config.dataPointIndex],
+            class: this._fullClassNames[config.dataPointIndex],
             status: this._filteredStatuses[config.seriesIndex]
         }
 

--- a/report-ng/app/src/main.ts
+++ b/report-ng/app/src/main.ts
@@ -76,6 +76,7 @@ export function configure(aurelia: Aurelia) {
             PLATFORM.moduleName('value-converters/html-value-converter'),
             PLATFORM.moduleName('value-converters/log-level-value-converter'),
             PLATFORM.moduleName('value-converters/html-escape-value-converter'),
+            PLATFORM.moduleName('value-converters/class-name-value-converter'),
             /**
              * This is super important to dialogs
              * https://discourse.aurelia.io/t/solved-error-cannot-determine-default-view-strategy-for-object/3589/2

--- a/report-ng/app/src/value-converters/class-name-value-converter.ts
+++ b/report-ng/app/src/value-converters/class-name-value-converter.ts
@@ -1,0 +1,49 @@
+/*
+ * Testerra
+ *
+ * (C) 2023, Martin Großmann, T-Systems Multimedia Solutions GmbH, Deutsche Telekom AG
+ *
+ * Deutsche Telekom AG and all other contributors /
+ * copyright owners license this file to you under the Apache
+ * License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {autoinject} from "aurelia-framework";
+
+@autoinject()
+export class ClassNameValueConverter {
+
+    toView(value: string, mode: ClassName) {
+        switch (mode) {
+            case ClassName.package:
+                if (value.lastIndexOf('.') > 0) {
+                    return value.substr(0, value.lastIndexOf('.'));
+                }
+            case ClassName.simpleName:
+                if (value.lastIndexOf('.') > 0) {
+                    return value.substr(value.lastIndexOf('.') + 1);
+                }
+            case ClassName.full:
+                return value;
+        }
+        return value;
+    }
+}
+
+
+export enum ClassName {
+    full = 0,
+    simpleName,
+    package
+}

--- a/report-ng/app/src/value-converters/class-name-value-converter.ts
+++ b/report-ng/app/src/value-converters/class-name-value-converter.ts
@@ -29,6 +29,8 @@ export class ClassNameValueConverter {
             case ClassName.package:
                 if (value.lastIndexOf('.') > 0) {
                     return value.substr(0, value.lastIndexOf('.'));
+                } else {
+                    return '';
                 }
             case ClassName.simpleName:
                 if (value.lastIndexOf('.') > 0) {


### PR DESCRIPTION
# Description

The name of a `ClassContext` was only created by the the simple name of a class, not the full name. The report cannot distinguish if test classes in different packages have the same name.

With this change the full name in `ClassContext` is used in Testerra execution results. To keep a clear ReportNG it still shows only the simple name but in method details the package is listed as additional information.

As a little gimmick I added `TestClassContext` tests because they were missing. They 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
