### PR TITLE
Removed regular expressions from error message of hasWords assertion

### DIFF
--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/DefaultStringAssertion.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/DefaultStringAssertion.java
@@ -110,6 +110,8 @@ public class DefaultStringAssertion<T> extends DefaultQuantityAssertion<T> imple
                 .collect(Collectors.joining("|"));
         final Pattern wordsPattern = Pattern.compile(wordsList, Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
 
+        final String wordsListWithoutRegex = String.join("|", words);
+
         return propertyAssertionFactory.createWithParent(DefaultBinaryAssertion.class, this, new AssertionProvider<Boolean>() {
             @Override
             public Boolean getActual() {
@@ -121,7 +123,7 @@ public class DefaultStringAssertion<T> extends DefaultQuantityAssertion<T> imple
 
             @Override
             public String createSubject() {
-                return "has words " + Format.param(wordsList);
+                return "has words " + Format.param(wordsListWithoutRegex);
             }
         });
     }


### PR DESCRIPTION
# Description

The error message of the hasWords assertion included regular expressions, which were also shown in the testerra report and made it more difficult to read.

Those regular expressions were removed from the error message to improve the readability.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
