### PR TITLE
Fix/layoutcheck distance image writing

### DIFF
--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/layout/LayoutCheck.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/layout/LayoutCheck.java
@@ -30,7 +30,7 @@ import eu.tsystems.mms.tic.testframework.layout.reporting.LayoutCheckContext;
 import eu.tsystems.mms.tic.testframework.report.Report;
 import eu.tsystems.mms.tic.testframework.report.utils.ExecutionContextController;
 import eu.tsystems.mms.tic.testframework.utils.AssertUtils;
-import org.apache.commons.io.FileUtils;
+import eu.tsystems.mms.tic.testframework.utils.FileUtils;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.TakesScreenshot;
 import org.openqa.selenium.WebDriver;
@@ -330,8 +330,12 @@ public final class LayoutCheck implements PropertyManagerProvider {
 
         try {
             // Write image to given file
-            resultFilename.toFile().getParentFile().mkdirs();
-            ImageIO.write(distanceImage, "PNG", resultFilename.toAbsolutePath().toFile());
+            File tempDistanceImage = new FileUtils().createTempFileName(resultFilename.getFileName().toString());
+            ImageIO.write(distanceImage, "PNG", tempDistanceImage);
+            if (resultFilename.toFile().exists()) {
+                resultFilename.toFile().delete();
+            }
+            FileUtils.moveFile(tempDistanceImage, resultFilename.toFile());
         } catch (IOException ioe) {
             LOGGER.error(
                     String.format("An error occurred while trying to persist image to '%s'.", resultFilename),
@@ -381,7 +385,7 @@ public final class LayoutCheck implements PropertyManagerProvider {
      * Calculates the sizes that result from the minimum sizes of both pictures.
      *
      * @param expectedImage The expected image
-     * @param actualImage   The actual image
+     * @param actualImage The actual image
      * @return Calculated minimum size of the images
      */
     private static Dimension calculateMinImageSize(

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/layout/LayoutCheck.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/layout/LayoutCheck.java
@@ -315,6 +315,10 @@ public final class LayoutCheck implements PropertyManagerProvider {
 
         try {
             // Write image to given file
+            // Note:
+            //      The distance image needs to be created first in a temp dir and moved then to the destination dir
+            //      Cause: Executing a 'gradle test' with option '-p <project-dir>' causes a mismatch of working directory. It is still the project root dir,
+            //      but the subdirectory is needed. 'org.apache.commons.io.FileUtil.FileUtils' can handle this, but not 'ImageIO'.
             File tempDistanceImage = new FileUtils().createTempFileName(resultFilename.getFileName().toString());
             ImageIO.write(distanceImage, "PNG", tempDistanceImage);
             if (resultFilename.toFile().exists()) {

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/layout/LayoutCheck.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/layout/LayoutCheck.java
@@ -276,21 +276,6 @@ public final class LayoutCheck implements PropertyManagerProvider {
                 distanceImageSize.width, distanceImageSize.height,
                 expectedImage.getType());
 
-        Dimension expectedImageDimension = new Dimension(expectedImage.getWidth(), expectedImage.getHeight());
-        Dimension actualImageDimension = new Dimension(actualImage.getWidth(), actualImage.getHeight());
-
-        if (!actualImageDimension.equals(expectedImageDimension)) {
-            OptionalAssert.fail(
-                    String.format(
-                            "The actual image (width=%dpx, height=%dpx) has a different size than the reference image (width=%dpx, height=%dpx)",
-                            actualImageDimension.width,
-                            actualImageDimension.height,
-                            expectedImageDimension.width,
-                            expectedImageDimension.height
-                    )
-            );
-        }
-
         int ignoreColor = getColorOfPixel(expectedImage, 0, 0);
 
         for (int currentY = 0; currentY < distanceImageSize.height; currentY++) {
@@ -346,6 +331,10 @@ public final class LayoutCheck implements PropertyManagerProvider {
 
         // calculate and return the percentage number of pixels in error
         double result = ((double) pixelsInError / (totalPixels - noOfIgnoredPixels)) * 100;
+
+        // Just for debug log
+        Dimension expectedImageDimension = new Dimension(expectedImage.getWidth(), expectedImage.getHeight());
+        Dimension actualImageDimension = new Dimension(actualImage.getWidth(), actualImage.getHeight());
         LOGGER.debug("Raw results of pixel check: \n" +
                         "Dimension actual image: {}\n" +
                         "Dimension expected image: {}\n" +

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -38,6 +38,10 @@ test {
         s = ['src/test/resources/Pretest_Tests.xml']
     }
 
+    def pg = findProperty("pg")
+    if (pg) {
+        s = ['src/test/resources/Smoke.xml']
+    }
 
     useTestNG() {
         suites s

--- a/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/playground/DriverAndGuiElementTest.java
+++ b/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/playground/DriverAndGuiElementTest.java
@@ -84,8 +84,8 @@ public class DriverAndGuiElementTest extends AbstractTestSitesTest implements Ui
     public void testFailing() throws Exception {
         DesktopWebDriverRequest request = new DesktopWebDriverRequest();
         request.setBaseUrl("http://google.de");
-        request.setWebDriverMode(WebDriverMode.local);
-        request.setBrowser(Browsers.phantomjs);
+//        request.setWebDriverMode(WebDriverMode.local);
+//        request.setBrowser(Browsers.phantomjs);
 
         WEB_DRIVER_MANAGER.getWebDriver(request);
         Assert.assertTrue(false);

--- a/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/layoutcheck/LayoutCheckTest.java
+++ b/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/layoutcheck/LayoutCheckTest.java
@@ -29,7 +29,6 @@ import eu.tsystems.mms.tic.testframework.pageobjects.GuiElement;
 import eu.tsystems.mms.tic.testframework.pageobjects.LocatorFactoryProvider;
 import eu.tsystems.mms.tic.testframework.pageobjects.Page;
 import eu.tsystems.mms.tic.testframework.pageobjects.UiElement;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 public class LayoutCheckTest extends AbstractTestSitesTest implements LocatorFactoryProvider {
@@ -58,48 +57,40 @@ public class LayoutCheckTest extends AbstractTestSitesTest implements LocatorFac
 
     @Test
     public void testT02_CheckElementLayoutWithSubfolder() {
-        GuiElement guiElement = getGuiElementQa("section/layoutTestArticle");
-        guiElement.asserts().assertScreenshot("subfolder/TestArticle", 1.3);
+        UiElement uiElement = getUIElementQa("section/layoutTestArticle");
+        uiElement.assertThat().screenshot().pixelDistance("subfolder/TestArticle").isLowerThan(1.3);
 
-        guiElement = getGuiElementQa("section/invisibleTestArticle");
-        guiElement.asserts().assertScreenshot("subfolder/InvisibleTestArticle", 1.3);
+        uiElement = getUIElementQa("section/invisibleTestArticle");
+        uiElement.assertThat().screenshot().pixelDistance("subfolder/InvisibleTestArticle").isLowerThan(1.3);
     }
 
     @Test
     public void testT03_CheckElementVisibility() {
-        GuiElement guiElement = getGuiElementQa("section/layoutTestArticle");
-        Page helperPage = new Page(guiElement.getWebDriver());
+        UiElement uiElement = getUIElementQa("section/layoutTestArticle");
+        Page helperPage = new Page(uiElement.getWebDriver());
         int top = helperPage.expect().viewport().top().getActual();
 
-        guiElement.asserts().assertVisible(true);
-        Assert.assertTrue(guiElement.isVisible(true));
+        uiElement.assertThat().visibleFull().is(true);
 
-        guiElement = getGuiElementQa("section/invisibleTestArticle");
-        guiElement.asserts().assertNotVisible();
-        Assert.assertFalse(guiElement.isVisible(true));
+        uiElement = getUIElementQa("section/invisibleTestArticle");
+        uiElement.assertThat().visibleFull().is(false);
 
-        // Scroll to offset doesn't work
-        //guiElement.scrollToElement(300);
-        //Assert.assertFalse(guiElement.isVisible(true));
-
-        guiElement.scrollIntoView();
-
+        uiElement.scrollIntoView();
         helperPage.expect().viewport().top().isGreaterThan(top);
 
-        Assert.assertTrue(guiElement.isVisible(true));
-        guiElement.asserts().assertVisible(true);
+        uiElement.assertThat().visibleFull().is(true);
     }
 
     @Test(expectedExceptions = AssertionError.class)
     public void testT04_CheckElementLayoutDistance_fails() {
-        GuiElement guiElement = getGuiElementQa("section/layoutTestArticle");
-        guiElement.asserts().assertScreenshot("TestArticleFailed", 1);
+        UiElement uiElement = getUIElementQa("section/layoutTestArticle");
+        uiElement.assertThat().screenshot().pixelDistance("TestArticleFailed").isLowerThan(1);
     }
 
     @Test(expectedExceptions = AssertionError.class)
     public void testT05_CheckElementLayoutSize_fails() {
-        GuiElement guiElement = getGuiElementQa("section/layoutTestArticle");
-        guiElement.asserts().assertScreenshot("TestArticle-90-percent-width", 1);
+        UiElement uiElement = getUIElementQa("section/layoutTestArticle");
+        uiElement.assertThat().screenshot().pixelDistance("TestArticle-90-percent-width").isLowerThan(1);
     }
 
     @Test

--- a/integration-tests/src/test/resources/Smoke.xml
+++ b/integration-tests/src/test/resources/Smoke.xml
@@ -5,7 +5,11 @@
     <test name="test1">
         <classes>
 <!--            <class name="eu.tsystems.mms.tic.testframework.test.common.PropertyManagerTest"></class>-->
-            <class name="eu.tsystems.mms.tic.testframework.test.page.AssertTextPageTest"></class>
+            <class name="eu.tsystems.mms.tic.testframework.test.layoutcheck.LayoutCheckTest">
+                <methods>
+                    <include name="testT01_CheckElementLayout"/>
+                </methods>
+            </class>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
# Description

Executing a test with `gradle -p <subproject-dir> test` causes a mismatch of the working directory. It is still the project root dir but the subdirectory is needed.
`org.apache.commons.io.FileUtil.FileUtils` can handle this, but not `ImageIO`. This was the only place in the code where images were not stored in a temporary directory.

I also fixed the check of image dimensions which causes multiple optional assertions in the report.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
