### PR TITLE
Fix/reportng error message

### DIFF
--- a/report-ng/app/src/components/failure-aspects/failure-aspects.html
+++ b/report-ng/app/src/components/failure-aspects/failure-aspects.html
@@ -74,7 +74,8 @@
                                 >${failureAspect.index+1}</td>
                                 <td class="p1 wrapable" mdc-body1>
                                     <a route-href="route: tests; params.bind: {failureAspect: failureAspect.index+1}"
-                                    ><class-name-markup namespace.bind="failureAspect.relevantCause.className" highlight.bind="_searchRegexp">:</class-name-markup><span>${failureAspect.message|highlightText:_searchRegexp}</span></a>
+                                    ><class-name-markup namespace.bind="failureAspect.relevantCause.className" highlight.bind="_searchRegexp">:</class-name-markup>
+                                    <span innerhtml.bind="failureAspect.message|highlightText:_searchRegexp"></span></a>
                                 </td>
                                 <td>
                                     <div repeat.for="status of failureAspect.availableStatuses" class="mt1 mb1">

--- a/report-ng/app/src/services/statistic-models.ts
+++ b/report-ng/app/src/services/statistic-models.ts
@@ -230,12 +230,18 @@ export class FailureAspectStatistics extends Statistics {
             this.message = this.errorContext.description;
         } else if (this.relevantCause) {
             // Cut the identifier message to first occurrence of line-break
-            const breakPos = this.relevantCause.message?.indexOf("\n");
-            if (breakPos >= 0) {
-                this.message = this.relevantCause.message.substring(0, breakPos);
-            } else {
-                this.message = this.relevantCause.message;
-            }
+
+            // Note: In specific cases, this caused the loss of valuable information
+            // about the occurring error, which then could not be seen in the report.
+            // const breakPos = this.relevantCause.message?.indexOf("\n");
+            // if (breakPos >= 0) {
+            //     this.message = this.relevantCause.message.substring(0, breakPos);
+            // } else {
+            //     this.message = this.relevantCause.message;
+            // }
+
+            // Replace all occurring line-breaks with a space-character
+            this.message = this.relevantCause.message.replaceAll('\n', ' ');
             this.message = this.message.trim();
             this.identifier = this.relevantCause.className + this.message;
         }

--- a/report-ng/app/src/services/statistic-models.ts
+++ b/report-ng/app/src/services/statistic-models.ts
@@ -229,17 +229,6 @@ export class FailureAspectStatistics extends Statistics {
             this.identifier = this.errorContext.description;
             this.message = this.errorContext.description;
         } else if (this.relevantCause) {
-            // Cut the identifier message to first occurrence of line-break
-
-            // Note: In specific cases, this caused the loss of valuable information
-            // about the occurring error, which then could not be seen in the report.
-            // const breakPos = this.relevantCause.message?.indexOf("\n");
-            // if (breakPos >= 0) {
-            //     this.message = this.relevantCause.message.substring(0, breakPos);
-            // } else {
-            //     this.message = this.relevantCause.message;
-            // }
-
             // Replace all occurring line-breaks with a space-character
             this.message = this.relevantCause.message.replaceAll('\n', ' ');
             this.message = this.message.trim();


### PR DESCRIPTION
# Description

In specific cases, the cut of the identifier message in statistic-models caused the loss of valuable information about the occurring error, which then could not be seen in the report. This was fixed by replacing occurring line-breaks with a space-character.

Error message before change:
![error_message_before](https://github.com/telekom/testerra/assets/113340362/a132d964-9339-429f-bc71-2304f5f7c3ae)

Error message afte change:
![error_message_after](https://github.com/telekom/testerra/assets/113340362/b8fe4fd5-aa85-4fdc-b1f8-5048fa6d95af)


In Addition in the failure-aspects-view of the testerra report, the highlighting of occurring strings in the error message did not work properly, which was fixed as well.

Failure Aspects before change:
![failure_aspects_before](https://github.com/telekom/testerra/assets/113340362/655a067d-9137-4856-b21d-6641ce31c5fb)

Failure Aspects after change:
![failure_aspects_after](https://github.com/telekom/testerra/assets/113340362/aa119f2a-7715-49fc-9055-ec624835e8a3)


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
