### PR TITLE
Added property to change timeout of uielement highlighting

### DIFF
--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/common/Testerra.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/common/Testerra.java
@@ -67,6 +67,7 @@ public class Testerra {
         DRY_RUN("tt.dryrun", false),
         MONITOR_MEMORY("tt.monitor.memory", true),
         DEMO_MODE("tt.demomode", false),
+        DEMO_MODE_TIMEOUT("tt.demomode.timeout", 2000),
         @Deprecated
         SELENIUM_SERVER_HOST("tt.selenium.server.host", null),
         @Deprecated

--- a/docs/src/docs/execution/execution-highlighting.adoc
+++ b/docs/src/docs/execution/execution-highlighting.adoc
@@ -2,7 +2,7 @@
 include::../properties/property-attributes.adoc[]
 
 == Demo mode
-In the demo mode actions on pages are marked with distinctive coloured frames around the element of the action. This mechanism is set by a property
+In the demo mode actions on pages are marked with distinctive coloured frames around the element of the action. This mechanism is set by a property:
 
 .test.properties
 [source, properties,subs="attributes"]
@@ -16,3 +16,14 @@ The following colours are used for highlighting
 * [green]#green#: successful visibility checks and asserts
 * [yellow]#yellow#: mouseOver
 * [blue]#blue#: click
+
+The highlighting is removed after a timeout of 2000 ms. You can set a custom timeout:
+
+.test.properties
+[source, properties,subs="attributes"]
+----
+# Set a custom timeout in ms
+# 0 -> infinite timeout
+# default is 2000
+{demomode_timeout}=5000
+----

--- a/docs/src/docs/properties/execution-probs.adoc
+++ b/docs/src/docs/properties/execution-probs.adoc
@@ -4,7 +4,7 @@ include::property-attributes.adoc[]
 |===
 | Property | default | Description
 | {demomode} | false | Visually marks every UiElement that is being processed by click, type or assert. This may break layout checks.
-| {demomode_timeout} | 2000 | Timeout in ms for visually marks of UiElements.
+| {demomode_timeout} | 2000 | Timeout in ms for visual marks of UiElements.
 | {dryrun} | false | All testmethods are executed with ignoring all steps. Also all setup methods (before, after) are ignored. +
 This is useful to check your TestNG suite without executing real testcode.
 | {list_tests} | false | Lists all test methods in the current context without executing them.

--- a/docs/src/docs/properties/execution-probs.adoc
+++ b/docs/src/docs/properties/execution-probs.adoc
@@ -4,6 +4,7 @@ include::property-attributes.adoc[]
 |===
 | Property | default | Description
 | {demomode} | false | Visually marks every UiElement that is being processed by click, type or assert. This may break layout checks.
+| {demomode_timeout} | 2000 | Timeout in ms for visually marks of UiElements.
 | {dryrun} | false | All testmethods are executed with ignoring all steps. Also all setup methods (before, after) are ignored. +
 This is useful to check your TestNG suite without executing real testcode.
 | {list_tests} | false | Lists all test methods in the current context without executing them.

--- a/docs/src/docs/properties/property-attributes.adoc
+++ b/docs/src/docs/properties/property-attributes.adoc
@@ -48,6 +48,7 @@
 // execution
 :dryrun:                                        tt.dryrun
 :demomode:                                      tt.demomode
+:demomode_timeout:                              tt.demomode.timeout
 :on_state_testfailed_skip_shutdown:             tt.on.state.testfailed.skip.shutdown
 :on_state_testfailed_skip_following_tests:      tt.on.state.testfailed.skip.following.tests
 :failed_tests_if_throwable_classes:             tt.failed.tests.if.throwable.classes

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/utils/JSUtils.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/utils/JSUtils.java
@@ -195,7 +195,7 @@ public final class JSUtils {
             WebElement webElement,
             Color color
     ) {
-        int ms = 2000;
+        long timeout = Testerra.Properties.DEMO_MODE_TIMEOUT.asLong();
         try {
             executeScriptWOCatch(
                     driver,
@@ -204,7 +204,7 @@ public final class JSUtils {
                             "ttHighlight(arguments[0], '%s', %d)",
                             readSnippets(Snippet.HIGHLIGHT),
                             toHex(color),
-                            ms
+                            timeout
                     ),
                     webElement
             );

--- a/driver-ui/src/main/resources/snippets/highlight.js
+++ b/driver-ui/src/main/resources/snippets/highlight.js
@@ -1,9 +1,11 @@
 function ttHighlight(element, color, timeout) {
     var origOutline = element.style.outline;
     ttAddStyle(element, "outline: 5px solid " + color + " !important");
-    window.setTimeout(function() {
-        element.style.outline = origOutline;
-    }, timeout);
+    if (timeout > 0) {
+        window.setTimeout(function () {
+            element.style.outline = origOutline;
+        }, timeout);
+    }
 }
 
 /**


### PR DESCRIPTION
# Description

The new property `tt.demomode.timeout` allows to set a custom timeout where the highlighting is removed. A value of `0` means an _infinite_ timeout.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
