### PR TITLE
Updated log4j2.xml example with Selenium 4 specifics

### DIFF
--- a/docs/src/docs/gettingstarted/logging.adoc
+++ b/docs/src/docs/gettingstarted/logging.adoc
@@ -3,7 +3,7 @@
 The log configuration prints out to `System.out` by default.
 If you want to have more control over several log levels of classes, add a `log4j2.xml` to your `resources/`.
 
-.log4j2.xml
+.debug level in log4j2.xml
 [source, xml]
 ----
 include::../../res/log4j2.xml[]
@@ -14,6 +14,8 @@ You can also change the root log level from the command line via.
 ----
 -Dlog4j.level=DEBUG
 ----
+
+NOTE: The shown `log4j2.xml` sets the `INFO` level for the package `org.asynchttpclient`. Otherwise Selenium 4 spams the logs with request/response information.
 
 == Log own messages
 

--- a/docs/src/res/log4j2.xml
+++ b/docs/src/res/log4j2.xml
@@ -9,8 +9,11 @@
             <PatternLayout pattern="%d{dd.MM.yyyy HH:mm:ss.SSS} [%t][%p]%contextIds: %c{2} - %m{nolookups}%n" />
         </Console>
     </Appenders>
+    <Logger name="org.asynchttpclient" level="info" additivity="false">
+        <AppenderRef ref="CONSOLE"/>
+    </Logger>
     <Loggers>
-        <Root level="info">
+        <Root level="debug">
             <AppenderRef ref="CONSOLE"/>
         </Root>
     </Loggers>


### PR DESCRIPTION
# Description

The used HTTP client in Selenium 4 spams the logs with huge number of request and response information when using `DEBUG` level. This PR updates the example for a custom `log4j2.xml`.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)