### PR TITLE
Fix/356 ttscreenshotteractive causes npe at collected assertions

### DIFF
--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/execution/testng/DefaultOptionalAssertion.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/execution/testng/DefaultOptionalAssertion.java
@@ -46,11 +46,13 @@ public class DefaultOptionalAssertion extends AbstractAssertion implements
 
             // get screenshots
             List<Screenshot> screenshots = TestEvidenceCollector.collectScreenshots();
-            Report report = Testerra.getInjector().getInstance(Report.class);
-            screenshots.forEach(screenshot -> {
-                methodContext.addScreenshot(screenshot);
-                report.addScreenshot(screenshot, Report.FileMode.MOVE);
-            });
+            if (screenshots != null) {
+                Report report = Testerra.getInjector().getInstance(Report.class);
+                screenshots.forEach(screenshot -> {
+                    methodContext.addScreenshot(screenshot);
+                    report.addScreenshot(screenshot, Report.FileMode.MOVE);
+                });
+            }
         });
     }
 }

--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/execution/testng/DefaultOptionalAssertion.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/execution/testng/DefaultOptionalAssertion.java
@@ -46,13 +46,12 @@ public class DefaultOptionalAssertion extends AbstractAssertion implements
 
             // get screenshots
             List<Screenshot> screenshots = TestEvidenceCollector.collectScreenshots();
-            if (screenshots != null) {
-                Report report = Testerra.getInjector().getInstance(Report.class);
-                screenshots.forEach(screenshot -> {
-                    methodContext.addScreenshot(screenshot);
-                    report.addScreenshot(screenshot, Report.FileMode.MOVE);
-                });
-            }
+
+            Report report = Testerra.getInjector().getInstance(Report.class);
+            screenshots.forEach(screenshot -> {
+                methodContext.addScreenshot(screenshot);
+                report.addScreenshot(screenshot, Report.FileMode.MOVE);
+            });
         });
     }
 }

--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/interop/TestEvidenceCollector.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/interop/TestEvidenceCollector.java
@@ -51,11 +51,11 @@ public final class TestEvidenceCollector {
 
     public static List<Screenshot> collectScreenshots() {
         if (!Testerra.Properties.SCREENSHOTTER_ACTIVE.asBool()) {
-            return null;
+            return List.of();
         }
 
         if (SCREENSHOT_COLLECTORS.isEmpty()) {
-            return null;
+            return List.of();
         }
 
         List<Screenshot> screenshots = new LinkedList<>();

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/execution/worker/finish/TakeInSessionEvidencesWorker.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/execution/worker/finish/TakeInSessionEvidencesWorker.java
@@ -26,8 +26,8 @@ import eu.tsystems.mms.tic.testframework.common.Testerra;
 import eu.tsystems.mms.tic.testframework.events.MethodEndEvent;
 import eu.tsystems.mms.tic.testframework.interop.TestEvidenceCollector;
 import eu.tsystems.mms.tic.testframework.report.Report;
-import eu.tsystems.mms.tic.testframework.report.TestStatusController;
 import eu.tsystems.mms.tic.testframework.report.model.context.Screenshot;
+
 import java.util.List;
 
 public class TakeInSessionEvidencesWorker implements MethodEndEvent.Listener {
@@ -36,13 +36,12 @@ public class TakeInSessionEvidencesWorker implements MethodEndEvent.Listener {
         // get screenshots and videos
         List<Screenshot> screenshots = TestEvidenceCollector.collectScreenshots();
 
-        if (screenshots != null) {
-            Report report = Testerra.getInjector().getInstance(Report.class);
-            screenshots.forEach(screenshot -> {
-                methodEndEvent.getMethodContext().addScreenshot(screenshot);
-                report.addScreenshot(screenshot, Report.FileMode.MOVE);
-            });
-        }
+        Report report = Testerra.getInjector().getInstance(Report.class);
+        screenshots.forEach(screenshot -> {
+            methodEndEvent.getMethodContext().addScreenshot(screenshot);
+            report.addScreenshot(screenshot, Report.FileMode.MOVE);
+        });
+
     }
 
     @Override

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/execution/worker/finish/TakeInSessionEvidencesWorker.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/execution/worker/finish/TakeInSessionEvidencesWorker.java
@@ -36,12 +36,13 @@ public class TakeInSessionEvidencesWorker implements MethodEndEvent.Listener {
         // get screenshots and videos
         List<Screenshot> screenshots = TestEvidenceCollector.collectScreenshots();
 
-        Report report = Testerra.getInjector().getInstance(Report.class);
-        screenshots.forEach(screenshot -> {
-            methodEndEvent.getMethodContext().addScreenshot(screenshot);
-            report.addScreenshot(screenshot, Report.FileMode.MOVE);
-        });
-
+        if (screenshots != null) {
+            Report report = Testerra.getInjector().getInstance(Report.class);
+            screenshots.forEach(screenshot -> {
+                methodEndEvent.getMethodContext().addScreenshot(screenshot);
+                report.addScreenshot(screenshot, Report.FileMode.MOVE);
+            });
+        }
     }
 
     @Override

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/execution/worker/finish/TakeInSessionEvidencesWorker.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/execution/worker/finish/TakeInSessionEvidencesWorker.java
@@ -36,13 +36,11 @@ public class TakeInSessionEvidencesWorker implements MethodEndEvent.Listener {
         // get screenshots and videos
         List<Screenshot> screenshots = TestEvidenceCollector.collectScreenshots();
 
-        if (screenshots != null) {
-            Report report = Testerra.getInjector().getInstance(Report.class);
-            screenshots.forEach(screenshot -> {
-                methodEndEvent.getMethodContext().addScreenshot(screenshot);
-                report.addScreenshot(screenshot, Report.FileMode.MOVE);
-            });
-        }
+        Report report = Testerra.getInjector().getInstance(Report.class);
+        screenshots.forEach(screenshot -> {
+            methodEndEvent.getMethodContext().addScreenshot(screenshot);
+            report.addScreenshot(screenshot, Report.FileMode.MOVE);
+        });
     }
 
     @Override


### PR DESCRIPTION
# Description

Fixes an NPE when using property `tt.screenshotter.active=false`.

Fixes #356 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
