### PR TITLE
UiElementList Iterator

### DIFF
--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/internal/AbstractUiElementList.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/internal/AbstractUiElementList.java
@@ -29,12 +29,13 @@ import java.util.Iterator;
 
 public abstract class AbstractUiElementList<SELF extends UiElementBase> implements UiElementList<SELF> {
     private final SELF uiElement;
-    private int iteratorIndex = 0;
+    private int iteratorIndex;
     private int iteratorSize;
     private int size;
 
     public AbstractUiElementList(SELF uiElement) {
         this.uiElement = uiElement;
+        this.iteratorIndex = 0;
         this.size = size();
         this.iteratorSize = this.size;
     }

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/internal/AbstractUiElementList.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/internal/AbstractUiElementList.java
@@ -24,6 +24,7 @@ package eu.tsystems.mms.tic.testframework.pageobjects.internal;
 import eu.tsystems.mms.tic.testframework.internal.asserts.QuantityAssertion;
 import eu.tsystems.mms.tic.testframework.pageobjects.UiElementList;
 import eu.tsystems.mms.tic.testframework.pageobjects.internal.core.UiElementBase;
+
 import java.util.Iterator;
 
 public abstract class AbstractUiElementList<SELF extends UiElementBase> implements UiElementList<SELF> {
@@ -34,7 +35,7 @@ public abstract class AbstractUiElementList<SELF extends UiElementBase> implemen
 
     public AbstractUiElementList(SELF uiElement) {
         this.uiElement = uiElement;
-
+        iteratorSize = size();
     }
 
     @Override
@@ -48,8 +49,9 @@ public abstract class AbstractUiElementList<SELF extends UiElementBase> implemen
 
     @Override
     public boolean isEmpty() {
-        return this.size==0;
+        return this.size == 0;
     }
+
     @Override
     public Iterator<SELF> iterator() {
         iteratorIndex = 0;

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/internal/AbstractUiElementList.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/internal/AbstractUiElementList.java
@@ -30,12 +30,13 @@ import java.util.Iterator;
 public abstract class AbstractUiElementList<SELF extends UiElementBase> implements UiElementList<SELF> {
     private final SELF uiElement;
     private int iteratorIndex = 0;
-    private int iteratorSize = 0;
-    private int size = 0;
+    private int iteratorSize;
+    private int size;
 
     public AbstractUiElementList(SELF uiElement) {
         this.uiElement = uiElement;
-        iteratorSize = size();
+        this.size = size();
+        this.iteratorSize = this.size;
     }
 
     @Override

--- a/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/guielement/UiElementListTests.java
+++ b/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/guielement/UiElementListTests.java
@@ -27,6 +27,7 @@ import eu.tsystems.mms.tic.testframework.pageobjects.UiElement;
 import eu.tsystems.mms.tic.testframework.pageobjects.UiElementList;
 import eu.tsystems.mms.tic.testframework.test.core.pageobjects.testdata.UiElementListPage;
 import eu.tsystems.mms.tic.testframework.test.core.pageobjects.testdata.components.TableRow;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 public class UiElementListTests extends AbstractExclusiveTestSitesTest<UiElementListPage> {
@@ -116,6 +117,16 @@ public class UiElementListTests extends AbstractExclusiveTestSitesTest<UiElement
         tableRows.list().first().linkByXPath().expect().attribute(Attribute.HREF).endsWith("mkri").is(true);
         tableRows.list().get(1).linkByXPath().expect().attribute(Attribute.HREF).endsWith("joku").is(true);
         tableRows.list().last().linkByXPath().expect().attribute(Attribute.HREF).endsWith("erku").is(true);
+    }
+
+    @Test
+    public void test_iterator() {
+        UiElementListPage page = getPage();
+        final UiElement anchors = page.getNavigationSubElementsByTagName();
+        anchors.expect().foundElements().is(3);
+        UiElementList<UiElement> list = anchors.list();
+        Assert.assertTrue(list.hasNext());
+        Assert.assertTrue(list.iterator().hasNext());
     }
 
     @Override


### PR DESCRIPTION
# Description

When calling `hasNext()` on an `UiElementList`, the result was always `false`, because the size of the list was not initialized.
I wrote a test which failed before my fix.
I added the initialization of `iteratorSize` to the constructor of `AbstractUiElementList`. This fixed the problem and made the test pass.
In a second commit, for consistency I also added the initializaion of `size` to the constructor.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
