### PR TITLE
fixed overflowing of stacktrace lines and assertion error title

### DIFF
--- a/report-ng/app/src/components/method-details/details.html
+++ b/report-ng/app/src/components/method-details/details.html
@@ -34,7 +34,7 @@
         <mdc-card mdc-elevation="4"  class="mb1" repeat.for="errorDetail of _errorDetails" >
 
             <div class="p1 status-${_methodDetails.methodContext.resultStatus|statusClass} upper-rounded">
-                <div mdc-headline5><class-name-markup namespace.bind="errorDetail.failureAspect.relevantCause.className">:</class-name-markup><span>${errorDetail.failureAspect.message}</span></div>
+                <div mdc-headline5 class="overflow-wrap"><class-name-markup namespace.bind="errorDetail.failureAspect.relevantCause.className">:</class-name-markup><span>${errorDetail.failureAspect.message}</span></div>
                 <div class="mt1" if.bind="errorDetail.layoutCheckContext">
                     <layout-comparison context.bind="errorDetail.layoutCheckContext"></layout-comparison>
                 </div>

--- a/report-ng/app/src/components/method-details/details.scss
+++ b/report-ng/app/src/components/method-details/details.scss
@@ -1,0 +1,24 @@
+/*!
+ * Testerra
+ *
+ * (C) 2023, Telekom MMS GmbH, Deutsche Telekom AG
+ *
+ * Deutsche Telekom AG and all other contributors /
+ * copyright owners license this file to you under the Apache
+ * License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+.overflow-wrap, .line {
+    overflow-wrap: anywhere;
+}

--- a/report-ng/app/src/components/method-details/details.ts
+++ b/report-ng/app/src/components/method-details/details.ts
@@ -36,6 +36,8 @@ import {data} from "../../services/report-model";
 import {MdcSnackbarService} from '@aurelia-mdc-web/snackbar';
 import {Clipboard} from "t-systems-aurelia-components/src/utils/clipboard";
 import IStackTraceCause = data.StackTraceCause;
+import "./details.scss"
+
 
 interface ErrorDetails {
     failureAspect: FailureAspectStatistics;


### PR DESCRIPTION
# Description

The issue was that there was overflowing in the error details view. There were two main reasons: if the title of the error reason was too long and without spaces, the title was not wrapping to the next line. Same issue with the logs of stack traces. 
I fixed both using `overflow-wrap: anywhere;`

Before: 
![image](https://github.com/telekom/testerra/assets/138661340/573b4b42-a1ee-4ae3-a728-d3778d091ddb)

After:
![image](https://github.com/telekom/testerra/assets/138661340/6f81d3dc-2cb4-4a16-9053-10d0447f5b1f)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
