### PR TITLE
Bugfix failure aspects

### DIFF
--- a/report-ng/app/src/components/failure-aspects/failure-aspects.html
+++ b/report-ng/app/src/components/failure-aspects/failure-aspects.html
@@ -64,7 +64,7 @@
                         <thead>
                             <th class="centered-text">Rank</th>
                             <th class="w75">Failure Aspect</th>
-                            <th>Statuses</th>
+                            <th>Status</th>
                         </thead>
                         <tbody>
                             <tr repeat.for="failureAspect of _filteredFailureAspects">

--- a/report-ng/app/src/components/method-details/details.scss
+++ b/report-ng/app/src/components/method-details/details.scss
@@ -1,7 +1,7 @@
 /*!
  * Testerra
  *
- * (C) 2023, Telekom MMS GmbH, Deutsche Telekom AG
+ * (C) 2023, Deutsche Telekom MMS GmbH, Deutsche Telekom AG
  *
  * Deutsche Telekom AG and all other contributors /
  * copyright owners license this file to you under the Apache

--- a/report-ng/app/src/components/method-details/method.html
+++ b/report-ng/app/src/components/method-details/method.html
@@ -60,9 +60,9 @@
                     >
                         <span class="badge status-failed-expected sr1">@Fails</span>
                         <div>
-                            <div if.bind="_methodDetails.failsAnnotation.description&&7!= _methodDetails.methodContext.resultStatus">${_methodDetails.failsAnnotation.description}</div>
-                            <div if.bind="_methodDetails.failsAnnotation.ticketString&&7!= _methodDetails.methodContext.resultStatus">Ticket: <span innerhtml.bind="_methodDetails.failsAnnotation.ticketString|html"></span></div>
-                            <div if.bind="_methodDetails.failsAnnotation.validator&&7== _methodDetails.methodContext.resultStatus">Your conditions for Expected fails were not fulfilled: <br> ${_methodDetails.failsAnnotation.validator}</div>
+                            <div class="overflow-wrap" if.bind="_methodDetails.failsAnnotation.description&&7!= _methodDetails.methodContext.resultStatus">${_methodDetails.failsAnnotation.description}</div>
+                            <div class="overflow-wrap" if.bind="_methodDetails.failsAnnotation.ticketString&&7!= _methodDetails.methodContext.resultStatus">Ticket: <span innerhtml.bind="_methodDetails.failsAnnotation.ticketString|html"></span></div>
+                            <div class="overflow-wrap" if.bind="_methodDetails.failsAnnotation.validator&&7== _methodDetails.methodContext.resultStatus">Your conditions for Expected fails were not fulfilled: <br> ${_methodDetails.failsAnnotation.validator}</div>
                         </div>
                     </div>
                     <mdc-list-divider if.bind="_methodDetails.failsAnnotation"></mdc-list-divider>
@@ -117,13 +117,13 @@
                                 <mdc-layout-grid-cell span="6">
                                     <div if.bind="_prevMethod">
                                         <span class="secondary sr1">Previous failed method</span>
-                                        <a route-href="route: method; params.bind: {methodId: _prevMethod.methodContext.contextValues.id}" class="sr1">${_prevMethod.identifier}</a>
+                                        <a route-href="route: method; params.bind: {methodId: _prevMethod.methodContext.contextValues.id}" class="sr1 overflow-wrap">${_prevMethod.identifier}</a>
                                     </div>
                                 </mdc-layout-grid-cell>
                                 <mdc-layout-grid-cell span="6" class="right-aligned">
                                     <div if.bind="_nextMethod">
                                         <span class="secondary sl1 sr1">Next failed method</span>
-                                        <a route-href="route: method; params.bind: {methodId: _nextMethod.methodContext.contextValues.id}" class="sr1">${_nextMethod.identifier}</a>
+                                        <a route-href="route: method; params.bind: {methodId: _nextMethod.methodContext.contextValues.id}" class="sr1 overflow-wrap">${_nextMethod.identifier}</a>
                                     </div>
                                 </mdc-layout-grid-cell>
                             </mdc-layout-grid-inner>

--- a/report-ng/app/src/components/method-details/method.scss
+++ b/report-ng/app/src/components/method-details/method.scss
@@ -1,7 +1,7 @@
 /*!
  * Testerra
  *
- * (C) 2023, Telekom MMS GmbH, Deutsche Telekom AG
+ * (C) 2023, Deutsche Telekom MMS GmbH, Deutsche Telekom AG
  *
  * Deutsche Telekom AG and all other contributors /
  * copyright owners license this file to you under the Apache

--- a/report-ng/app/src/components/method-details/method.scss
+++ b/report-ng/app/src/components/method-details/method.scss
@@ -1,0 +1,24 @@
+/*!
+ * Testerra
+ *
+ * (C) 2023, Telekom MMS GmbH, Deutsche Telekom AG
+ *
+ * Deutsche Telekom AG and all other contributors /
+ * copyright owners license this file to you under the Apache
+ * License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+.overflow-wrap {
+    overflow-wrap: anywhere;
+}

--- a/report-ng/app/src/components/method-details/method.ts
+++ b/report-ng/app/src/components/method-details/method.ts
@@ -26,6 +26,7 @@ import {IScreenshotsDialogParams, ScreenshotsDialog} from "../screenshots-dialog
 import {MdcDialogService} from '@aurelia-mdc-web/dialog';
 import {data} from "../../services/report-model";
 import MethodType = data.MethodType;
+import "./method.scss"
 
 @autoinject()
 export class Method {

--- a/report-ng/app/src/services/statistic-models.ts
+++ b/report-ng/app/src/services/statistic-models.ts
@@ -66,7 +66,8 @@ class Statistics {
                 upmostStatus = status;
             }
         }
-        return (upmostStatus == 10 && this._resultStatuses.hasOwnProperty(7)) ? 7 : upmostStatus; // if there is the same failure aspect for one failed and one expected failed test, the failed class color should be displayed
+        return (upmostStatus == data.ResultStatusType.FAILED_EXPECTED && this._resultStatuses.hasOwnProperty(data.ResultStatusType.FAILED))
+            ? data.ResultStatusType.FAILED : upmostStatus; // if there is the same failure aspect for one failed and one expected failed test, the failed class color should be displayed
     }
 
     protected addStatistics(statistics: Statistics) {

--- a/report-ng/app/src/services/statistic-models.ts
+++ b/report-ng/app/src/services/statistic-models.ts
@@ -66,7 +66,7 @@ class Statistics {
                 upmostStatus = status;
             }
         }
-        return upmostStatus;
+        return (upmostStatus == 10 && this._resultStatuses.hasOwnProperty(7)) ? 7 : upmostStatus; // if there is the same failure aspect for one failed and one expected failed test, the failed class color should be displayed
     }
 
     protected addStatistics(statistics: Statistics) {


### PR DESCRIPTION
# Description
* fixed spelling mistake Statuses -> Status
* on dashboard is a top 3 failure aspects list: if there is a failure aspect that has one failed test and one expected failed test, the color of the icon represents the expected failed color (dark red), but it should display the failed color (light red)

Fixes # (issue)
* added a check: if the color is dark red (expected failed), it additionally checks if there is a test with the failed-status. If that is true, it returns light red (failed), if not it returns the color that was originally calculated

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
