### PR TITLE
Fix/mail connector read message contents

### DIFF
--- a/mail-connector/src/main/java/eu/tsystems/mms/tic/testframework/mailconnector/util/Email.java
+++ b/mail-connector/src/main/java/eu/tsystems/mms/tic/testframework/mailconnector/util/Email.java
@@ -163,18 +163,18 @@ public class Email implements Loggable {
                     encoding = part.getContentType();
                     encoding = getCharSetForEncoding(encoding);
 
-                    if (j == 0) {
+                    if (BodyPart.ATTACHMENT.equalsIgnoreCase(part.getDisposition())) {
+                        // Attachment
+                        String fileName = part.getFileName();
+                        EmailAttachment attachment = new EmailAttachment(fileName, is, encoding);
+                        attachments.add(attachment);
+                    } else {
                         // Message content
                         try {
                             messageText = IOUtils.toString(is, encoding).replaceAll("\r", "");
                         } catch (IllegalCharsetNameException e) {
                             log().error("Unable to encode input stream", e);
                         }
-                    } else {
-                        // Attachment
-                        String fileName = part.getFileName();
-                        EmailAttachment attachment = new EmailAttachment(fileName, is, encoding);
-                        attachments.add(attachment);
                     }
 
                 } // end for

--- a/mail-connector/src/main/java/eu/tsystems/mms/tic/testframework/mailconnector/util/Email.java
+++ b/mail-connector/src/main/java/eu/tsystems/mms/tic/testframework/mailconnector/util/Email.java
@@ -23,6 +23,7 @@ package eu.tsystems.mms.tic.testframework.mailconnector.util;
 
 import eu.tsystems.mms.tic.testframework.logging.Loggable;
 import jakarta.mail.Address;
+import jakarta.mail.BodyPart;
 import jakarta.mail.MessagingException;
 import jakarta.mail.Multipart;
 import jakarta.mail.Part;
@@ -158,18 +159,20 @@ public class Email implements Loggable {
                 Multipart content = (Multipart) message.getContent();
 
                 for (int j = 0; j < content.getCount(); j++) {
-                    Part part = content.getBodyPart(j);
+                    BodyPart part = content.getBodyPart(j);
                     is = part.getInputStream();
                     encoding = part.getContentType();
                     encoding = getCharSetForEncoding(encoding);
 
-                    if (part.getDisposition().equals(Part.INLINE)) {
+                    if (j == 0) {
+                        // Message content
                         try {
                             messageText = IOUtils.toString(is, encoding).replaceAll("\r", "");
                         } catch (IllegalCharsetNameException e) {
                             log().error("Unable to encode input stream", e);
                         }
-                    } else if (part.getDisposition().equals(Part.ATTACHMENT)) {
+                    } else {
+                        // Attachment
                         String fileName = part.getFileName();
                         EmailAttachment attachment = new EmailAttachment(fileName, is, encoding);
                         attachments.add(attachment);

--- a/mail-connector/src/main/java/eu/tsystems/mms/tic/testframework/mailconnector/util/Email.java
+++ b/mail-connector/src/main/java/eu/tsystems/mms/tic/testframework/mailconnector/util/Email.java
@@ -26,7 +26,6 @@ import jakarta.mail.Address;
 import jakarta.mail.BodyPart;
 import jakarta.mail.MessagingException;
 import jakarta.mail.Multipart;
-import jakarta.mail.Part;
 import jakarta.mail.internet.MimeMessage;
 import org.apache.commons.io.IOUtils;
 
@@ -235,7 +234,7 @@ public class Email implements Loggable {
      * @param fileName name of the attachment file
      * @return attachment
      */
-    public EmailAttachment getAttachment(String fileName) throws IOException {
+    public EmailAttachment getAttachment(String fileName) {
         for (EmailAttachment attachment : attachments) {
             if (attachment.getFileName().equals(fileName)) {
                 return attachment;

--- a/mail-connector/src/test/java/eu/tsystems/mms/tic/testframework/mailconnector/test/MailConnectorTest.java
+++ b/mail-connector/src/test/java/eu/tsystems/mms/tic/testframework/mailconnector/test/MailConnectorTest.java
@@ -220,7 +220,7 @@ public class MailConnectorTest extends TesterraTest implements Loggable {
      * POP3MailConnector.
      */
     @Test
-    public void testT02_sendAndWaitForMessageWithoutAttachement() throws MessagingException {
+    public void testT02_sendAndWaitForMessageWithoutAttachment() throws MessagingException {
 
         final String subject = STR_MAIL_SUBJECT + "testT02_sendAndWaitForMessage";
 
@@ -507,9 +507,9 @@ public class MailConnectorTest extends TesterraTest implements Loggable {
      * @throws Exception Exception by mail submission
      */
     @Test
-    public void testT08_sendAndWaitForMessageWithoutAttachement_SubjectSenderRecipient() throws Exception {
+    public void testT08_sendAndWaitForMessageWithoutAttachment_SubjectSenderRecipient() throws Exception {
 
-        final String subject = "testT08_sendAndWaitForMessageWithoutAttachement_SubjectSenderRecipient"
+        final String subject = "testT08_sendAndWaitForMessageWithoutAttachment_SubjectSenderRecipient"
                 + RandomStringUtils.random(5, true, false);
 
         final SearchTerm searchTerm = new AndTerm(new SearchTerm[]{
@@ -518,7 +518,7 @@ public class MailConnectorTest extends TesterraTest implements Loggable {
                 new RecipientTerm(RecipientType.TO, new InternetAddress(RECIPIENT))
         });
 
-        sendAndWaitForMessageWithoutAttachement(subject, searchTerm);
+        sendAndWaitForMessageWithoutAttachment(subject, searchTerm);
     }
 
     /**
@@ -527,16 +527,16 @@ public class MailConnectorTest extends TesterraTest implements Loggable {
      * @throws Exception Exception by mail submission
      */
     @Test
-    public void testT09_sendAndWaitForMessageWithoutAttachement_SubjectRecipient() throws Exception {
+    public void testT09_sendAndWaitForMessageWithoutAttachment_SubjectRecipient() throws Exception {
 
-        final String subject = "testT09_sendAndWaitForMessageWithoutAttachement_SubjectRecipient"
+        final String subject = "testT09_sendAndWaitForMessageWithoutAttachment_SubjectRecipient"
                 + RandomStringUtils.random(5, true, false);
 
         final SearchTerm searchTerm = new AndTerm(
                 new SubjectTerm(subject),
                 new FromTerm(new InternetAddress(SENDER)));
 
-        sendAndWaitForMessageWithoutAttachement(subject, searchTerm);
+        sendAndWaitForMessageWithoutAttachment(subject, searchTerm);
     }
 
     /**
@@ -545,16 +545,16 @@ public class MailConnectorTest extends TesterraTest implements Loggable {
      * @throws Exception Exception by mail submission
      */
     @Test
-    public void testT10_sendAndWaitForMessageWithoutAttachement_SubjectSender() throws Exception {
+    public void testT10_sendAndWaitForMessageWithoutAttachment_SubjectSender() throws Exception {
 
-        final String subject = "testT10_sendAndWaitForMessageWithoutAttachement_SubjectSender"
+        final String subject = "testT10_sendAndWaitForMessageWithoutAttachment_SubjectSender"
                 + RandomStringUtils.random(5, true, false);
 
         final SearchTerm searchTerm = new AndTerm(
                 new SubjectTerm(subject),
                 new FromTerm(new InternetAddress(SENDER)));
 
-        sendAndWaitForMessageWithoutAttachement(subject, searchTerm);
+        sendAndWaitForMessageWithoutAttachment(subject, searchTerm);
     }
 
     /**
@@ -563,9 +563,9 @@ public class MailConnectorTest extends TesterraTest implements Loggable {
      * @throws Exception Exception by mail submission
      */
     @Test
-    public void testT12_sendAndWaitForMessageWithoutAttachement_SubjectSentDate() throws Exception {
+    public void testT12_sendAndWaitForMessageWithoutAttachment_SubjectSentDate() throws Exception {
 
-        final String subject = "testT12_sendAndWaitForMessageWithoutAttachement_SubjectSentDate";
+        final String subject = "testT12_sendAndWaitForMessageWithoutAttachment_SubjectSentDate";
 
         Date now = new Date();
         Date aMinuteBefore = new Date(now.getTime() - (1000 * 60));
@@ -576,7 +576,7 @@ public class MailConnectorTest extends TesterraTest implements Loggable {
                 new SentDateTerm(ComparisonTerm.GE, aMinuteBefore)
         );
 
-        sendAndWaitForMessageWithoutAttachement(subject, searchTerm);
+        sendAndWaitForMessageWithoutAttachment(subject, searchTerm);
     }
 
     /**
@@ -619,8 +619,8 @@ public class MailConnectorTest extends TesterraTest implements Loggable {
         deleteMessage(receivedMsg, imap, targetFolder);
     }
 
-    private void sendAndWaitForMessageWithoutAttachement(final String testname,
-                                                         final SearchTerm searchTerm) throws MessagingException, IOException {
+    private void sendAndWaitForMessageWithoutAttachment(final String testname,
+                                                        final SearchTerm searchTerm) throws MessagingException, IOException {
 
         final String subject = STR_MAIL_SUBJECT + testname;
 


### PR DESCRIPTION
# Description

When an `Email` object was created, it was possible that a `NullPointerException` could be thrown, if the disposition of a part of this multipart message was unknown. The if-Statement for the distinction of the part (either `INLINE` or `ATTACHMENT`) was replaced to work reliably, even if the disposition is unknown. In addition some typos in `MailConnectorTest` were fixed.

Fixes #371 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
