### PR TITLE
Updated clone method of capabilities

### DIFF
--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/utils/DefaultCapabilityUtils.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/utils/DefaultCapabilityUtils.java
@@ -21,14 +21,13 @@
 
 package eu.tsystems.mms.tic.testframework.utils;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import eu.tsystems.mms.tic.testframework.logging.Loggable;
 import org.apache.commons.lang3.StringUtils;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -63,14 +62,40 @@ public class DefaultCapabilityUtils implements Loggable {
         return Collections.unmodifiableMap(clonedMap);
     }
 
-    /**
-     * For deep cloning it is needed convert it to JSON and back because Firefox options also contain some immutable map objects
-     * Note: Complex objects are simplified to key-value pairs. This is acceptable because capabilities are always simplified to a kind of Map<String, Object>
-     */
     public Map<String, Object> clone(Map<String, Object> capabilityMap) {
-        Gson gson = new GsonBuilder().create();
-        String json = gson.toJson(capabilityMap);
-        return (Map<String, Object>) gson.fromJson(json, Map.class);
+        return cloneMap(capabilityMap);
+    }
+
+    // Recursive method to deep clone the capability map
+    // (Firefox options also contain some immutable map objects)
+    private static Map<String, Object> cloneMap(Map<String, Object> originalMap) {
+        Map<String, Object> clonedMap = new HashMap<>();
+
+        for (Map.Entry<String, Object> entry : originalMap.entrySet()) {
+            String key = entry.getKey();
+            Object value = entry.getValue();
+
+            if (value instanceof Map) {
+                Map<String, Object> nestedClone = cloneMap((Map<String, Object>) value);
+                clonedMap.put(key, nestedClone);
+            } else {
+                // Note: Non-map values are not real cloned
+                clonedMap.put(key, value);
+                // ObjectMapper to try to clone the value
+//                try {
+//                    ObjectMapper objectMapper = new ObjectMapper();
+//                    String json = objectMapper.writeValueAsString(entry);
+//                    TypeReference<Map<String, Object>> typeRef = new TypeReference<Map<String, Object>>() {
+//                    };
+//                    Map<String, Object> mappedClone = objectMapper.readValue(json, typeRef);
+//                    clonedMap.put(key, mappedClone.get(key));
+//                } catch (JsonProcessingException e) {
+//                    clonedMap.put(key, null);
+//                }
+
+            }
+        }
+        return clonedMap;
     }
 
     /**

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/AbstractWebDriverRequest.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/AbstractWebDriverRequest.java
@@ -199,7 +199,8 @@ public class AbstractWebDriverRequest implements WebDriverRequest, Loggable {
      * -> We have to backup the current caps and clone WebDriverRequest without caps. After cloning the original caps are added again.
      * -> org.apache.commons.lang3.SerializationUtils cannot used because not all objects are serializable (e.g. Proxy)
      * -> merge()-Method does not clone capability values like Maps (e.g. goog:chromeOptions, no deep copy)
-     * --> used Gson lib
+     * -> Gson or Jackson wrapper to convert it to json and back can destroy special objects
+     * --> used recursive clone method in DefaultCapabilityUtils.clone()
      */
     public AbstractWebDriverRequest clone() throws CloneNotSupportedException {
         AbstractWebDriverRequest clone = (AbstractWebDriverRequest) super.clone();

--- a/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/playground/DriverAndGuiElementTest.java
+++ b/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/playground/DriverAndGuiElementTest.java
@@ -33,25 +33,26 @@ import eu.tsystems.mms.tic.testframework.useragents.ChromeConfig;
 import eu.tsystems.mms.tic.testframework.useragents.FirefoxConfig;
 import eu.tsystems.mms.tic.testframework.utils.UITestUtils;
 import eu.tsystems.mms.tic.testframework.webdrivermanager.DesktopWebDriverRequest;
-import eu.tsystems.mms.tic.testframework.webdrivermanager.WebDriverSessionsManager;
-import eu.tsystems.mms.tic.testframework.webdrivermanager.desktop.WebDriverMode;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.firefox.FirefoxProfile;
+import org.openqa.selenium.logging.LogType;
+import org.openqa.selenium.logging.LoggingPreferences;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import java.util.Map;
-
 import java.io.File;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.logging.Level;
 
 public class DriverAndGuiElementTest extends AbstractTestSitesTest implements UiElementFinderFactoryProvider, PageFactoryProvider {
 
     @Test
-    public void testUiElement()  {
+    public void testUiElement() {
         WebDriver driver = getWebDriver();
 
         UiElementFinder uiElementFinder = UI_ELEMENT_FINDER_FACTORY.create(driver);
@@ -132,5 +133,22 @@ public class DriverAndGuiElementTest extends AbstractTestSitesTest implements Ui
 //        PAGE_FACTORY.createPage(PageWithNotExistingElement.class);
         PAGE_FACTORY.createPage(PageWithExistingElement.class, webDriver);
         UITestUtils.takeScreenshot(webDriver, true);
+    }
+
+    @Test
+    public void test_specialCaps() {
+        DesktopWebDriverRequest request = new DesktopWebDriverRequest();
+        ChromeOptions options = new ChromeOptions();
+        options.addArguments("--browser.download.folderList=2");
+        options.addArguments("--browser.helperApps.neverAsk.saveToDisk=text/csv, application/pdf,application/pdf,application/x-pdf,application/zip,application/x-zip-compressed,multipart/x-zip");
+        LoggingPreferences logPrefs = new LoggingPreferences();
+        logPrefs.enable(LogType.PERFORMANCE, Level.ALL);
+        options.setCapability("goog:loggingPrefs", logPrefs);
+        final Map<String, Object> prefs = new HashMap<>();
+        prefs.put("intl.accept_languages", "de-DE");
+        options.setExperimentalOption("prefs", prefs);
+        request.getMutableCapabilities().setCapability(ChromeOptions.CAPABILITY, options);
+
+        WEB_DRIVER_MANAGER.getWebDriver(request);
     }
 }


### PR DESCRIPTION
# Description

The clone method of capabilites was not working correctly. With very special caps it caused an exception in Gson lib with JDK17 .
Therefor the clone was rebuild without Gson or other libs.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
