### PR TITLE
Added a closing current window before closing the whole session

### DIFF
--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/WebDriverManagerUtils.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/WebDriverManagerUtils.java
@@ -83,6 +83,19 @@ public final class WebDriverManagerUtils {
      */
     protected static void quitWebDriverSession(final WebDriver driver) {
         try {
+            // With 'driver.quit()' sometimes some Chrome processes are left on host machine, take much of CPU resources
+            // If all current windows/tabs are closed before, 'driver.quit()' definitely shutdown the current browser
+            final int count = driver.getWindowHandles().size();
+            LOGGER.info("Closing all tabs ({}) of current session", count);
+            driver.getWindowHandles().forEach(handle -> {
+                driver.switchTo().window(handle);
+                driver.close();
+            });
+        } catch (final Throwable e) {
+            LOGGER.debug("Current browser window could not be closed.");
+            LOGGER.debug("", e);
+        }
+        try {
             driver.quit();
         } catch (final Throwable e) {
             LOGGER.warn("WebDriver could not be quit. May someone did before.", e);

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/WebDriverManagerUtils.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/WebDriverManagerUtils.java
@@ -92,8 +92,7 @@ public final class WebDriverManagerUtils {
                 driver.close();
             });
         } catch (final Throwable e) {
-            LOGGER.debug("Current browser window could not be closed.");
-            LOGGER.debug("", e);
+            LOGGER.debug("Current browser window could not be closed.", e);
         }
         try {
             driver.quit();


### PR DESCRIPTION
# Description

Closing the chrome session could left Chrome tasks on Windows, which takes much CPU resources. This only occures with desktop mode of Chrome, not with headless mode.
It's not clear, why this happens since Selenium 4. 

This PR provides a 'safer' close of the current session. Before `webdriver.quit()` all windows or tabs are closed with `webdriver.close()`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
