### PR TITLE
Added note if filter criteria could only match to configuration methods.

### DIFF
--- a/report-ng/app/src/components/classes/classes.html
+++ b/report-ng/app/src/components/classes/classes.html
@@ -175,7 +175,7 @@
                             <mdc-icon class="big-icon sr1">find_in_page</mdc-icon>
                             <div mdc-headline4>No methods matching this criteria</div>
                         </div>
-                        <div class="mt1" mdc-subtitle1 if.bind="!_showConfigurationMethods">Note, that your filter criteria could only match to configuration methods.</div>
+                        <div class="mt1" mdc-subtitle1 if.bind="!_showConfigurationMethods">Please note, that your filter criteria may only match configuration methods.</div>
                     </div>
                 </alert>
             </mdc-layout-grid-cell>

--- a/report-ng/app/src/components/classes/classes.html
+++ b/report-ng/app/src/components/classes/classes.html
@@ -35,7 +35,7 @@
                         <mdc-list-item repeat.for="status of _availableStatuses"
                                        value.bind="status"
                         >
-                            <span class="badge status-${status|statusClass}">${status|statusName}</span>
+                            <span class="badge status-${status|statusClass}">${status | statusName}</span>
                         </mdc-list-item>
                     </mdc-list>
                 </mdc-select>
@@ -83,11 +83,11 @@
                 >
                     <table>
 
-                    <thead>
+                        <thead>
                         <th class="status-column centered-text">Status (${_uniqueStatuses})</th>
                         <th class="mdc-data-table__header-cell" click.delegate="_sortByRunIndex()">
-                            <div class="mdc-data-table__header-cell-wrapper" >
-                                <div class="mdc-data-table__header-cell-label" >Run index</div>
+                            <div class="mdc-data-table__header-cell-wrapper">
+                                <div class="mdc-data-table__header-cell-label">Run index</div>
                                 <button class="mdc-icon-button material-icons mdc-data-table__sort-icon-button">arrow_upward</button>
                             </div>
                         </th>
@@ -108,7 +108,7 @@
                         <tbody>
                         <tr repeat.for="methodDetails of _filteredMethodDetails">
                             <td class="p1 centered-text">
-                                <a class="badge status-${methodDetails.methodContext.resultStatus|statusClass}">${methodDetails.methodContext.resultStatus|statusName}</a>
+                                <a class="badge status-${methodDetails.methodContext.resultStatus|statusClass}">${methodDetails.methodContext.resultStatus | statusName}</a>
                             </td>
                             <td class="run-index-cell">${methodDetails.methodContext.methodRunIndex}</td>
                             <td class="p1 wrapable">
@@ -136,12 +136,13 @@
                                      if.bind="methodDetails.failsAnnotation.description || methodDetails.failsAnnotation.ticketString"
                                 >
                                     <mdc-icon class="colored-icon status-${methodDetails.methodContext.resultStatus|statusClass}">highlight_off</mdc-icon>
-                                    <ul class="mdc-list mdc-list--dense"  mdc-caption>
+                                    <ul class="mdc-list mdc-list--dense" mdc-caption>
                                         <li class="mdc-custom-list-item" if.bind="methodDetails.failsAnnotation.description&&7!= methodDetails.methodContext.resultStatus">
                                             <span innerhtml.bind="methodDetails.failsAnnotation.description|highlightText:_searchRegexp"></span>
                                         </li>
                                         <li class="mdc-custom-list-item" if.bind="methodDetails.failsAnnotation.ticketString&&7!= methodDetails.methodContext.resultStatus">
-                                            Ticket:&nbsp;<a href="${methodDetails.failsAnnotation.ticketString}" innerhtml.bind="methodDetails.failsAnnotation.ticketString|highlightText:_searchRegexp"></a>
+                                            Ticket:&nbsp;<a href="${methodDetails.failsAnnotation.ticketString}"
+                                                            innerhtml.bind="methodDetails.failsAnnotation.ticketString|highlightText:_searchRegexp"></a>
                                         </li>
                                     </ul>
                                 </div>
@@ -151,7 +152,7 @@
                                      if.bind="methodDetails.promptLogs.length > 0"
                                 >
                                     <mdc-icon>speaker_notes</mdc-icon>
-                                    <ul class="mdc-list mdc-list--dense"  mdc-caption>
+                                    <ul class="mdc-list mdc-list--dense" mdc-caption>
                                         <li class="mdc-custom-list-item" repeat.for="logMessage of methodDetails.promptLogs">
                                             <span innerhtml.bind="logMessage.message|html|highlightText:_searchRegexp"></span>
                                         </li>
@@ -165,12 +166,17 @@
 
                             </td>
                         </tr>
-                    </tbody>
+                        </tbody>
                     </table>
                 </mdc-data-table>
                 <alert if.bind="!_loading && !_filteredMethodDetails.length">
-                    <mdc-icon class="big-icon sr1">find_in_page</mdc-icon>
-                    <div mdc-headline4>No methods matching this criteria</div>
+                    <div style="display: grid;">
+                        <div class="flex">
+                            <mdc-icon class="big-icon sr1">find_in_page</mdc-icon>
+                            <div mdc-headline4>No methods matching this criteria</div>
+                        </div>
+                        <div class="mt1" mdc-subtitle1 if.bind="!_showConfigurationMethods">Note, that your filter criteria could only match to configuration methods.</div>
+                    </div>
                 </alert>
             </mdc-layout-grid-cell>
         </mdc-layout-grid-inner>


### PR DESCRIPTION
# Description

Added a minor note in test table that filter criteria could only match to configuration methods: Coming from Failure aspects the selected aspect only occurs in a configuratio method.

![image](https://github.com/telekom/testerra/assets/22025965/3ec3f4b3-5880-4fad-8180-6d5a1218a6dd)

The little hint is removed if switch for config methods is active:
![image](https://github.com/telekom/testerra/assets/22025965/ccf80174-68a8-443e-94cb-ce237213f67e)


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
