### PR TITLE
Refactor stringassertion

### DIFF
--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/AbstractPropertyAssertion.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/AbstractPropertyAssertion.java
@@ -40,7 +40,7 @@ public abstract class AbstractPropertyAssertion<T> implements ActualProperty<T> 
     protected final AbstractPropertyAssertion<T> parent;
     protected PropertyAssertionConfig config;
 
-    public AbstractPropertyAssertion(AbstractPropertyAssertion parentAssertion, AssertionProvider<T> provider) {
+    public AbstractPropertyAssertion(AbstractPropertyAssertion<T> parentAssertion, AssertionProvider<T> provider) {
         this.parent = parentAssertion;
         this.provider = provider;
     }

--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/FileAssertion.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/FileAssertion.java
@@ -29,8 +29,8 @@ import java.io.File;
  */
 public interface FileAssertion extends ActualProperty<File> {
     QuantityAssertion<Long> bytes();
-    StringAssertion<String> name();
-    StringAssertion<String> extension();
-    StringAssertion<String> mimetype();
+    StringAssertion name();
+    StringAssertion extension();
+    StringAssertion mimetype();
     BinaryAssertion<Boolean> exists();
 }

--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/ObjectAssertion.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/ObjectAssertion.java
@@ -1,7 +1,7 @@
 /*
  * Testerra
  *
- * (C) 2023, Sebastian Kiehne, Deutsche Telekom MMS GmbH, Deutsche Telekom AG
+ * (C) 2024, Sebastian Kiehne, Deutsche Telekom MMS GmbH, Deutsche Telekom AG
  *
  * Deutsche Telekom AG and all other contributors /
  * copyright owners license this file to you under the Apache

--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/ObjectAssertion.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/ObjectAssertion.java
@@ -1,13 +1,36 @@
+/*
+ * Testerra
+ *
+ * (C) 2023, Sebastian Kiehne, Deutsche Telekom MMS GmbH, Deutsche Telekom AG
+ *
+ * Deutsche Telekom AG and all other contributors /
+ * copyright owners license this file to you under the Apache
+ * License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package eu.tsystems.mms.tic.testframework.internal.asserts;
 
 public interface ObjectAssertion<T> extends BinaryAssertion<T> {
     default boolean is(Object expected) {
         return is(expected, null);
     }
+
     boolean is(Object expected, String subject);
 
     default boolean isNot(Object expected) {
         return isNot(expected, null);
     }
+
     boolean isNot(Object expected, String subject);
 }

--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/ObjectAssertion.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/ObjectAssertion.java
@@ -1,6 +1,6 @@
 package eu.tsystems.mms.tic.testframework.internal.asserts;
 
-public interface ObjectAssertion<TYPE> extends BinaryAssertion<TYPE> {
+public interface ObjectAssertion<T> extends BinaryAssertion<T> {
     default boolean is(Object expected) {
         return is(expected, null);
     }

--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/ObjectAssertion.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/ObjectAssertion.java
@@ -1,0 +1,13 @@
+package eu.tsystems.mms.tic.testframework.internal.asserts;
+
+public interface ObjectAssertion<TYPE> extends BinaryAssertion<TYPE> {
+    default boolean is(Object expected) {
+        return is(expected, null);
+    }
+    boolean is(Object expected, String subject);
+
+    default boolean isNot(Object expected) {
+        return isNot(expected, null);
+    }
+    boolean isNot(Object expected, String subject);
+}

--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/QuantityAssertion.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/QuantityAssertion.java
@@ -28,16 +28,7 @@ import java.util.function.Function;
  * Allows numeric range based assertions
  * @author Mike Reiche
  */
-public interface QuantityAssertion<TYPE> extends BinaryAssertion<TYPE> {
-    default boolean is(Object expected) {
-        return is(expected, null);
-    }
-    boolean is(Object expected, String subject);
-
-    default boolean isNot(Object expected) {
-        return isNot(expected, null);
-    }
-    boolean isNot(Object expected, String subject);
+public interface QuantityAssertion<TYPE> extends ObjectAssertion<TYPE> {
 
     default boolean isGreaterThan(long expected) {
         return isGreaterThan(new BigDecimal(expected));
@@ -124,7 +115,7 @@ public interface QuantityAssertion<TYPE> extends BinaryAssertion<TYPE> {
     }
     boolean isBetween(BigDecimal lower, BigDecimal higher, String subject);
 
-    <MAPPED_TYPE> StringAssertion<MAPPED_TYPE> map(Function<? super TYPE, MAPPED_TYPE> mapFunction);
+    <MAPPED_TYPE> QuantityAssertion<MAPPED_TYPE> map(Function<? super TYPE, MAPPED_TYPE> mapFunction);
 
     QuantityAssertion<BigDecimal> absolute();
 }

--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/StringAssertion.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/StringAssertion.java
@@ -31,7 +31,7 @@ import java.util.stream.Collectors;
  * Allows string based assertions
  * @author Mike Reiche
  */
-public interface StringAssertion<TYPE> extends ObjectAssertion<TYPE> {
+public interface StringAssertion extends ObjectAssertion<String> {
     BinaryAssertion <Boolean> contains(String expected);
     BinaryAssertion <Boolean> startsWith(String expected);
     BinaryAssertion <Boolean> endsWith(String expected);
@@ -56,5 +56,5 @@ public interface StringAssertion<TYPE> extends ObjectAssertion<TYPE> {
         return contains(text).is(false);
     }
 
-    <MAPPED_TYPE> QuantityAssertion<MAPPED_TYPE> map(Function<? super TYPE, MAPPED_TYPE> mapFunction);
+    StringAssertion map(Function<String, String> mapFunction);
 }

--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/StringAssertion.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/StringAssertion.java
@@ -30,7 +30,7 @@ import java.util.stream.Collectors;
  * Allows string based assertions
  * @author Mike Reiche
  */
-public interface StringAssertion<T> extends QuantityAssertion<T> {
+public interface StringAssertion<T> extends ObjectAssertion<T> {
     BinaryAssertion <Boolean> contains(String expected);
     BinaryAssertion <Boolean> startsWith(String expected);
     BinaryAssertion <Boolean> endsWith(String expected);

--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/StringAssertion.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/StringAssertion.java
@@ -23,6 +23,7 @@ package eu.tsystems.mms.tic.testframework.internal.asserts;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -30,7 +31,7 @@ import java.util.stream.Collectors;
  * Allows string based assertions
  * @author Mike Reiche
  */
-public interface StringAssertion<T> extends ObjectAssertion<T> {
+public interface StringAssertion<TYPE> extends ObjectAssertion<TYPE> {
     BinaryAssertion <Boolean> contains(String expected);
     BinaryAssertion <Boolean> startsWith(String expected);
     BinaryAssertion <Boolean> endsWith(String expected);
@@ -54,4 +55,6 @@ public interface StringAssertion<T> extends ObjectAssertion<T> {
     default boolean isNotContaining(String text) {
         return contains(text).is(false);
     }
+
+    <MAPPED_TYPE> QuantityAssertion<MAPPED_TYPE> map(Function<? super TYPE, MAPPED_TYPE> mapFunction);
 }

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/AbstractTestedPropertyAssertion.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/AbstractTestedPropertyAssertion.java
@@ -46,7 +46,7 @@ public abstract class AbstractTestedPropertyAssertion<T> extends AbstractPropert
     protected static final Assertion assertionImpl = Testerra.getInjector().getInstance(Assertion.class);
     private static final TestController.Overrides overrides = Testerra.getInjector().getInstance(TestController.Overrides.class);
 
-    public AbstractTestedPropertyAssertion(AbstractPropertyAssertion parentAssertion, AssertionProvider<T> provider) {
+    public AbstractTestedPropertyAssertion(AbstractPropertyAssertion<T> parentAssertion, AssertionProvider<T> provider) {
         super(parentAssertion, provider);
     }
 

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/DefaultBinaryAssertion.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/DefaultBinaryAssertion.java
@@ -26,7 +26,7 @@ package eu.tsystems.mms.tic.testframework.internal.asserts;
  * @author Mike Reiche
  */
 public class DefaultBinaryAssertion<T> extends AbstractTestedPropertyAssertion<T> implements BinaryAssertion<T> {
-    public DefaultBinaryAssertion(AbstractPropertyAssertion parentAssertion, AssertionProvider<T> provider) {
+    public DefaultBinaryAssertion(AbstractPropertyAssertion<T> parentAssertion, AssertionProvider<T> provider) {
         super(parentAssertion, provider);
     }
 

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/DefaultFileAssertion.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/DefaultFileAssertion.java
@@ -32,7 +32,7 @@ import org.apache.commons.io.FilenameUtils;
  */
 public class DefaultFileAssertion extends AbstractPropertyAssertion<File> implements FileAssertion {
 
-    public DefaultFileAssertion(AbstractPropertyAssertion parentAssertion, AssertionProvider<File> provider) {
+    public DefaultFileAssertion(AbstractPropertyAssertion<File> parentAssertion, AssertionProvider<File> provider) {
         super(parentAssertion, provider);
     }
 
@@ -52,7 +52,7 @@ public class DefaultFileAssertion extends AbstractPropertyAssertion<File> implem
     }
 
     @Override
-    public StringAssertion<String> name() {
+    public StringAssertion name() {
         return propertyAssertionFactory.createWithParent(DefaultStringAssertion.class, this, new AssertionProvider<String>() {
             @Override
             public String getActual() {
@@ -67,7 +67,7 @@ public class DefaultFileAssertion extends AbstractPropertyAssertion<File> implem
     }
 
     @Override
-    public StringAssertion<String> extension() {
+    public StringAssertion extension() {
         return propertyAssertionFactory.createWithParent(DefaultStringAssertion.class, this, new AssertionProvider<String>() {
             @Override
             public String getActual() {
@@ -82,7 +82,7 @@ public class DefaultFileAssertion extends AbstractPropertyAssertion<File> implem
     }
 
     @Override
-    public StringAssertion<String> mimetype() {
+    public StringAssertion mimetype() {
         return propertyAssertionFactory.createWithParent(DefaultStringAssertion.class, this, new AssertionProvider<String>() {
             @Override
             public String getActual() {

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/DefaultObjectAssertion.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/DefaultObjectAssertion.java
@@ -1,3 +1,24 @@
+/*
+ * Testerra
+ *
+ * (C) 2023, Sebastian Kiehne, Deutsche Telekom MMS GmbH, Deutsche Telekom AG
+ *
+ * Deutsche Telekom AG and all other contributors /
+ * copyright owners license this file to you under the Apache
+ * License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package eu.tsystems.mms.tic.testframework.internal.asserts;
 
 public class DefaultObjectAssertion<T> extends DefaultBinaryAssertion<T> implements ObjectAssertion<T> {
@@ -5,6 +26,7 @@ public class DefaultObjectAssertion<T> extends DefaultBinaryAssertion<T> impleme
     public DefaultObjectAssertion(AbstractPropertyAssertion<T> parentAssertion, AssertionProvider<T> provider) {
         super(parentAssertion, provider);
     }
+
     @Override
     public boolean is(Object expected, String failMessage) {
         if (expected instanceof Boolean) {

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/DefaultObjectAssertion.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/DefaultObjectAssertion.java
@@ -1,7 +1,7 @@
 /*
  * Testerra
  *
- * (C) 2023, Sebastian Kiehne, Deutsche Telekom MMS GmbH, Deutsche Telekom AG
+ * (C) 2024, Sebastian Kiehne, Deutsche Telekom MMS GmbH, Deutsche Telekom AG
  *
  * Deutsche Telekom AG and all other contributors /
  * copyright owners license this file to you under the Apache

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/DefaultObjectAssertion.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/DefaultObjectAssertion.java
@@ -1,0 +1,34 @@
+package eu.tsystems.mms.tic.testframework.internal.asserts;
+
+public class DefaultObjectAssertion<T> extends DefaultBinaryAssertion<T> implements ObjectAssertion<T> {
+
+    public DefaultObjectAssertion(AbstractPropertyAssertion<T> parentAssertion, AssertionProvider<T> provider) {
+        super(parentAssertion, provider);
+    }
+    @Override
+    public boolean is(Object expected, String failMessage) {
+        if (expected instanceof Boolean) {
+            boolean expectedBoolean = (Boolean) expected;
+            return this.is(expectedBoolean, failMessage);
+        }
+        return testSequence(
+                provider,
+                (actual) -> assertionImpl.equals(actual, expected),
+                (actual) -> assertionImpl.formatExpectEquals(null, expected, createFailMessage(failMessage))
+        );
+    }
+
+    @Override
+    public boolean isNot(Object expected, String failMessage) {
+        if (expected instanceof Boolean) {
+            boolean expectedBoolean = (Boolean) expected;
+            return this.is(!expectedBoolean, failMessage);
+        } else {
+            return testSequence(
+                    provider,
+                    (actual) -> assertionImpl.notEquals(actual, expected),
+                    (actual) -> assertionImpl.formatExpectNotEquals(null, expected, createFailMessage(failMessage))
+            );
+        }
+    }
+}

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/DefaultPatternAssertion.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/DefaultPatternAssertion.java
@@ -29,7 +29,7 @@ import java.util.regex.Matcher;
  */
 public class DefaultPatternAssertion extends AbstractTestedPropertyAssertion<Matcher> implements PatternAssertion {
 
-    public DefaultPatternAssertion(AbstractPropertyAssertion parentAssertion, AssertionProvider<Matcher> provider) {
+    public DefaultPatternAssertion(AbstractPropertyAssertion<Matcher> parentAssertion, AssertionProvider<Matcher> provider) {
         super(parentAssertion, provider);
     }
 

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/DefaultPropertyAssertionFactory.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/DefaultPropertyAssertionFactory.java
@@ -31,10 +31,10 @@ import java.lang.reflect.InvocationTargetException;
  */
 public class DefaultPropertyAssertionFactory implements PropertyAssertionFactory, Loggable {
 
-    public <ASSERTION extends AbstractPropertyAssertion, TYPE> ASSERTION createAssertion(
+    public <ASSERTION extends AbstractPropertyAssertion, T> ASSERTION createAssertion(
             Class<ASSERTION> assertionClass,
             AbstractPropertyAssertion parentAssertion,
-            AssertionProvider<TYPE> provider
+            AssertionProvider<T> provider
     ) {
         ASSERTION assertion;
         try {
@@ -48,10 +48,10 @@ public class DefaultPropertyAssertionFactory implements PropertyAssertionFactory
     }
 
     @Override
-    public <ASSERTION extends AbstractPropertyAssertion, TYPE> ASSERTION createWithParent(
+    public <ASSERTION extends AbstractPropertyAssertion, T> ASSERTION createWithParent(
         Class<ASSERTION> assertionClass,
         AbstractPropertyAssertion parentAssertion,
-        AssertionProvider<TYPE> provider
+        AssertionProvider<T> provider
     ) {
         ASSERTION assertion = createAssertion(assertionClass, parentAssertion, provider);
         assertion.config = parentAssertion.config;

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/DefaultQuantityAssertion.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/DefaultQuantityAssertion.java
@@ -116,8 +116,8 @@ public class DefaultQuantityAssertion<TYPE> extends DefaultBinaryAssertion<TYPE>
     }
 
     @Override
-    public <MAPPED_TYPE> StringAssertion<MAPPED_TYPE> map(Function<? super TYPE, MAPPED_TYPE> mapFunction) {
-        return propertyAssertionFactory.createWithParent(DefaultStringAssertion.class, this, new AssertionProvider<MAPPED_TYPE>() {
+    public <MAPPED_TYPE> QuantityAssertion<MAPPED_TYPE> map(Function<? super TYPE, MAPPED_TYPE> mapFunction) {
+        return propertyAssertionFactory.createWithParent(DefaultQuantityAssertion.class, this, new AssertionProvider<MAPPED_TYPE>() {
             @Override
             public MAPPED_TYPE getActual() {
                 TYPE actual = provider.getActual();

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/DefaultQuantityAssertion.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/DefaultQuantityAssertion.java
@@ -29,37 +29,10 @@ import java.util.function.Function;
  *
  * @author Mike Reiche
  */
-public class DefaultQuantityAssertion<TYPE> extends DefaultBinaryAssertion<TYPE> implements QuantityAssertion<TYPE> {
+public class DefaultQuantityAssertion<TYPE> extends DefaultObjectAssertion<TYPE> implements QuantityAssertion<TYPE> {
 
     public DefaultQuantityAssertion(AbstractPropertyAssertion parentAssertion, AssertionProvider<TYPE> provider) {
         super(parentAssertion, provider);
-    }
-
-    @Override
-    public boolean is(Object expected, String failMessage) {
-        if (expected instanceof Boolean) {
-            boolean expectedBoolean = (Boolean) expected;
-            return this.is(expectedBoolean, failMessage);
-        }
-        return testSequence(
-                provider,
-                (actual) -> assertionImpl.equals(actual, expected),
-                (actual) -> assertionImpl.formatExpectEquals(null, expected, createFailMessage(failMessage))
-        );
-    }
-
-    @Override
-    public boolean isNot(Object expected, String failMessage) {
-        if (expected instanceof Boolean) {
-            boolean expectedBoolean = (Boolean) expected;
-            return this.is(!expectedBoolean, failMessage);
-        } else {
-            return testSequence(
-                    provider,
-                    (actual) -> assertionImpl.notEquals(actual, expected),
-                    (actual) -> assertionImpl.formatExpectNotEquals(null, expected, createFailMessage(failMessage))
-            );
-        }
     }
 
     private BigDecimal toBigDecimal(Object given) {

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/DefaultStringAssertion.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/DefaultStringAssertion.java
@@ -45,7 +45,7 @@ public class DefaultStringAssertion extends DefaultObjectAssertion<String> imple
         return propertyAssertionFactory.createWithParent(DefaultBinaryAssertion.class, this, new AssertionProvider<Boolean>() {
             @Override
             public Boolean getActual() {
-                return provider.getActual().toString().contains(expected);
+                return provider.getActual().contains(expected);
             }
 
             @Override
@@ -60,7 +60,7 @@ public class DefaultStringAssertion extends DefaultObjectAssertion<String> imple
         return propertyAssertionFactory.createWithParent(DefaultBinaryAssertion.class, this, new AssertionProvider<Boolean>() {
             @Override
             public Boolean getActual() {
-                return provider.getActual().toString().startsWith(expected);
+                return provider.getActual().startsWith(expected);
             }
 
             @Override
@@ -75,7 +75,7 @@ public class DefaultStringAssertion extends DefaultObjectAssertion<String> imple
         return propertyAssertionFactory.createWithParent(DefaultBinaryAssertion.class, this, new AssertionProvider<Boolean>() {
             @Override
             public Boolean getActual() {
-                return provider.getActual().toString().endsWith(expected);
+                return provider.getActual().endsWith(expected);
             }
 
             @Override
@@ -90,7 +90,7 @@ public class DefaultStringAssertion extends DefaultObjectAssertion<String> imple
         return propertyAssertionFactory.createWithParent(DefaultPatternAssertion.class, this, new AssertionProvider<Matcher>() {
             @Override
             public Matcher getActual() {
-                return pattern.matcher(provider.getActual().toString());
+                return pattern.matcher(provider.getActual());
             }
 
             @Override
@@ -111,13 +111,13 @@ public class DefaultStringAssertion extends DefaultObjectAssertion<String> imple
                 .collect(Collectors.joining("|"));
         final Pattern wordsPattern = Pattern.compile(wordsList, Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
 
-        final String wordsListWithoutRegex = java.lang.String.join("|", words);
+        final String wordsListWithoutRegex = String.join("|", words);
 
         return propertyAssertionFactory.createWithParent(DefaultBinaryAssertion.class, this, new AssertionProvider<Boolean>() {
             @Override
             public Boolean getActual() {
                 int found = 0;
-                Matcher matcher = wordsPattern.matcher(provider.getActual().toString());
+                Matcher matcher = wordsPattern.matcher(provider.getActual());
                 while (matcher.find()) found++;
                 return found == words.size();
             }
@@ -134,7 +134,7 @@ public class DefaultStringAssertion extends DefaultObjectAssertion<String> imple
         return propertyAssertionFactory.createWithParent(DefaultQuantityAssertion.class, this, new AssertionProvider<Integer>() {
             @Override
             public Integer getActual() {
-                return provider.getActual().toString().length();
+                return provider.getActual().length();
             }
 
             @Override

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/DefaultStringAssertion.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/DefaultStringAssertion.java
@@ -34,9 +34,9 @@ import java.util.stream.Collectors;
  *
  * @author Mike Reiche
  */
-public class DefaultStringAssertion<TYPE> extends DefaultQuantityAssertion<TYPE> implements StringAssertion<TYPE>, Loggable {
+public class DefaultStringAssertion extends DefaultObjectAssertion<String> implements StringAssertion, Loggable {
 
-    public DefaultStringAssertion(AbstractPropertyAssertion parentAssertion, AssertionProvider<TYPE> provider) {
+    public DefaultStringAssertion(AbstractPropertyAssertion<String> parentAssertion, AssertionProvider<String> provider) {
         super(parentAssertion, provider);
     }
 
@@ -111,7 +111,7 @@ public class DefaultStringAssertion<TYPE> extends DefaultQuantityAssertion<TYPE>
                 .collect(Collectors.joining("|"));
         final Pattern wordsPattern = Pattern.compile(wordsList, Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
 
-        final String wordsListWithoutRegex = String.join("|", words);
+        final String wordsListWithoutRegex = java.lang.String.join("|", words);
 
         return propertyAssertionFactory.createWithParent(DefaultBinaryAssertion.class, this, new AssertionProvider<Boolean>() {
             @Override
@@ -145,11 +145,11 @@ public class DefaultStringAssertion<TYPE> extends DefaultQuantityAssertion<TYPE>
     }
 
     @Override
-    public <MAPPED_TYPE> QuantityAssertion<MAPPED_TYPE> map(Function<? super TYPE, MAPPED_TYPE> mapFunction) {
-        return propertyAssertionFactory.createWithParent(DefaultQuantityAssertion.class, this, new AssertionProvider<MAPPED_TYPE>() {
+    public StringAssertion map(Function<String, String> mapFunction) {
+        return propertyAssertionFactory.createWithParent(DefaultStringAssertion.class, this, new AssertionProvider<String>() {
             @Override
-            public MAPPED_TYPE getActual() {
-                TYPE actual = provider.getActual();
+            public String getActual() {
+                String actual = provider.getActual();
                 if (actual == null) {
                     return null;
                 } else {
@@ -158,7 +158,7 @@ public class DefaultStringAssertion<TYPE> extends DefaultQuantityAssertion<TYPE>
             }
 
             @Override
-            public String createSubject() {
+            public java.lang.String createSubject() {
                 return "mapped to " + Format.shortString(getActual());
             }
         });

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/DefaultStringAssertion.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/internal/asserts/DefaultStringAssertion.java
@@ -24,6 +24,7 @@ package eu.tsystems.mms.tic.testframework.internal.asserts;
 import eu.tsystems.mms.tic.testframework.logging.Loggable;
 
 import java.util.List;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -33,9 +34,9 @@ import java.util.stream.Collectors;
  *
  * @author Mike Reiche
  */
-public class DefaultStringAssertion<T> extends DefaultQuantityAssertion<T> implements StringAssertion<T>, Loggable {
+public class DefaultStringAssertion<TYPE> extends DefaultQuantityAssertion<TYPE> implements StringAssertion<TYPE>, Loggable {
 
-    public DefaultStringAssertion(AbstractPropertyAssertion parentAssertion, AssertionProvider<T> provider) {
+    public DefaultStringAssertion(AbstractPropertyAssertion parentAssertion, AssertionProvider<TYPE> provider) {
         super(parentAssertion, provider);
     }
 
@@ -139,6 +140,26 @@ public class DefaultStringAssertion<T> extends DefaultQuantityAssertion<T> imple
             @Override
             public String createSubject() {
                 return "length";
+            }
+        });
+    }
+
+    @Override
+    public <MAPPED_TYPE> QuantityAssertion<MAPPED_TYPE> map(Function<? super TYPE, MAPPED_TYPE> mapFunction) {
+        return propertyAssertionFactory.createWithParent(DefaultQuantityAssertion.class, this, new AssertionProvider<MAPPED_TYPE>() {
+            @Override
+            public MAPPED_TYPE getActual() {
+                TYPE actual = provider.getActual();
+                if (actual == null) {
+                    return null;
+                } else {
+                    return mapFunction.apply(provider.getActual());
+                }
+            }
+
+            @Override
+            public String createSubject() {
+                return "mapped to " + Format.shortString(getActual());
             }
         });
     }

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/internal/DefaultPageAssertions.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/internal/DefaultPageAssertions.java
@@ -60,7 +60,7 @@ public class DefaultPageAssertions implements PageAssertions {
     }
 
     @Override
-    public StringAssertion<String> title() {
+    public StringAssertion title() {
         return propertyAssertionFactory.createWithConfig(DefaultStringAssertion.class, this.propertyAssertionConfig, new AssertionProvider<String>() {
             @Override
             public String getActual() {
@@ -75,7 +75,7 @@ public class DefaultPageAssertions implements PageAssertions {
     }
 
     @Override
-    public StringAssertion<String> url() {
+    public StringAssertion url() {
         return propertyAssertionFactory.createWithConfig(DefaultStringAssertion.class, this.propertyAssertionConfig, new AssertionProvider<String>() {
             @Override
             public String getActual() {

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/internal/asserts/DefaultUiElementAssertion.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/internal/asserts/DefaultUiElementAssertion.java
@@ -123,7 +123,7 @@ public class DefaultUiElementAssertion implements UiElementAssertion {
     }
 
     @Override
-    public StringAssertion<String> tagName() {
+    public StringAssertion tagName() {
         return propertyAssertionFactory.createWithConfig(DefaultStringAssertion.class, this.propertyAssertionConfig, new UiElementAssertionProvider<String>() {
             @Override
             public String getActual() {
@@ -138,7 +138,7 @@ public class DefaultUiElementAssertion implements UiElementAssertion {
     }
 
     @Override
-    public StringAssertion<String> text() {
+    public StringAssertion text() {
         return propertyAssertionFactory.createWithConfig(DefaultStringAssertion.class, this.propertyAssertionConfig, new UiElementAssertionProvider<String>() {
             @Override
             public String getActual() {
@@ -153,7 +153,7 @@ public class DefaultUiElementAssertion implements UiElementAssertion {
     }
 
     @Override
-    public StringAssertion<String> attribute(String attribute) {
+    public StringAssertion attribute(String attribute) {
         return propertyAssertionFactory.createWithConfig(DefaultStringAssertion.class, this.propertyAssertionConfig, new UiElementAssertionProvider<String>() {
             @Override
             public String getActual() {
@@ -168,7 +168,7 @@ public class DefaultUiElementAssertion implements UiElementAssertion {
     }
 
     @Override
-    public StringAssertion<String> css(String property) {
+    public StringAssertion css(String property) {
         return propertyAssertionFactory.createWithConfig(DefaultStringAssertion.class, this.propertyAssertionConfig, new UiElementAssertionProvider<String>() {
             @Override
             public String getActual() {

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/internal/asserts/PageAssertions.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/internal/asserts/PageAssertions.java
@@ -26,8 +26,8 @@ import eu.tsystems.mms.tic.testframework.internal.asserts.ScreenshotAssertion;
 import eu.tsystems.mms.tic.testframework.internal.asserts.StringAssertion;
 
 public interface PageAssertions extends ScreenshotAssertion {
-    StringAssertion<String> title();
-    StringAssertion<String> url();
+    StringAssertion title();
+    StringAssertion url();
     BinaryAssertion<Boolean> displayed();
 
     default boolean displayed(boolean bool) {

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/internal/asserts/UiElementAssertion.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/internal/asserts/UiElementAssertion.java
@@ -35,16 +35,16 @@ public interface UiElementAssertion extends UiElementBaseAssertion {
     default boolean text(Object text) {
         return text().is(text);
     }
-    StringAssertion<String> text();
+    StringAssertion text();
 
     default boolean value(Object text) {
         return value().is(text);
     }
-    default StringAssertion<String> value() {
+    default StringAssertion value() {
         return attribute(Attribute.VALUE);
     }
 
-    default StringAssertion<String> attribute(Attribute attribute) {
+    default StringAssertion attribute(Attribute attribute) {
         return attribute(attribute.toString());
     }
     default boolean attribute(Attribute attribute, Object expected) {
@@ -53,9 +53,9 @@ public interface UiElementAssertion extends UiElementBaseAssertion {
     default boolean attribute(String attribute, Object expected) {
         return this.attribute(attribute).is(expected);
     }
-    StringAssertion<String> attribute(String attribute);
+    StringAssertion attribute(String attribute);
 
-    StringAssertion<String> css(String property);
+    StringAssertion css(String property);
 
     BinaryAssertion<Boolean> enabled();
     default boolean enabled(boolean expected) {
@@ -72,7 +72,7 @@ public interface UiElementAssertion extends UiElementBaseAssertion {
         return selectable().is(expected);
     }
 
-    default StringAssertion<String> classes() {
+    default StringAssertion classes() {
         return this.attribute(Attribute.CLASS);
     }
 

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/internal/asserts/UiElementBaseAssertion.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/internal/asserts/UiElementBaseAssertion.java
@@ -64,7 +64,7 @@ public interface UiElementBaseAssertion extends ScreenshotAssertion {
         return visibleFull().is(expected);
     }
 
-    StringAssertion<String> tagName();
+    StringAssertion tagName();
 
     RectAssertion bounds();
 }

--- a/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/guielement/UiElementExpectAttributeTests.java
+++ b/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/guielement/UiElementExpectAttributeTests.java
@@ -44,7 +44,7 @@ public class UiElementExpectAttributeTests extends AbstractExclusiveTestSitesTes
     public void testT01_UiElement_disabled_attribute_present() {
         WebTestPage page = getPage();
         UiElementAssertion expect = page.getRadioBtn().expect();
-        StringAssertion<String> disabled = expect.attribute(Attribute.DISABLED);
+        StringAssertion disabled = expect.attribute(Attribute.DISABLED);
         disabled.isNot(null);
         disabled.isNot(false);
         disabled.isNot(Boolean.FALSE);

--- a/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/guielement/UiElementLayoutTests.java
+++ b/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/guielement/UiElementLayoutTests.java
@@ -209,7 +209,7 @@ public class UiElementLayoutTests extends AbstractExclusiveTestSitesTest<WebTest
         UiElement e1 = page.getFinder().findById(1);
         UiElement e2 = page.getFinder().findById(3);
         QuantityAssertion<Integer> integerQuantityAssertion = e1.expect().bounds().fromLeft().toLeftOf(e2);
-        integerQuantityAssertion.map(integer -> Math.abs(integer)).isLowerEqualThan(20);
+        integerQuantityAssertion.map(Math::abs).isLowerEqualThan(20);
         integerQuantityAssertion.absolute().isLowerEqualThan(20);
     }
 

--- a/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/page/PageTests.java
+++ b/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/page/PageTests.java
@@ -49,7 +49,7 @@ public class PageTests extends AbstractExclusiveTestSitesTest<WebTestPage> imple
     public void test_Page_title() {
         WebTestPage page = getPage();
 
-        StringAssertion<String> title = page.expect().title();
+        StringAssertion title = page.expect().title();
 
         title.is("Input test");
         title.isNot("Affentest");

--- a/report-ng-tests/src/main/java/io/testerra/report/test/pages/report/methodReport/ReportDetailsTab.java
+++ b/report-ng-tests/src/main/java/io/testerra/report/test/pages/report/methodReport/ReportDetailsTab.java
@@ -84,7 +84,7 @@ public class ReportDetailsTab extends AbstractReportMethodPage {
         if (expectedStatusTitleFormatted.equals(Status.FAILED_EXPECTED.title.toLowerCase(Locale.ROOT)))
             expectedStatusTitleFormatted = "failed-expected";
 
-        final StringAssertion<String> attributeClass = testFailureAspect.expect().attribute("class");
+        final StringAssertion attributeClass = testFailureAspect.expect().attribute("class");
         attributeClass.contains(expectedStatusTitleFormatted).is(true,
                 String.format("Failure Aspect status [%s] should correspond to method state [%s]",
                         attributeClass.getActual(),

--- a/templates/file-header.txt
+++ b/templates/file-header.txt
@@ -1,7 +1,7 @@
 /*
  * Testerra
  *
- * (C) 2021, YOUR_NAME,  T-Systems Multimedia Solutions GmbH, Deutsche Telekom AG
+ * (C) 2023, YOUR_NAME, Deutsche Telekom MMS GmbH, Deutsche Telekom AG
  *
  * Deutsche Telekom AG and all other contributors /
  * copyright owners license this file to you under the Apache

--- a/templates/file-header.txt
+++ b/templates/file-header.txt
@@ -1,7 +1,7 @@
 /*
  * Testerra
  *
- * (C) 2023, YOUR_NAME, Deutsche Telekom MMS GmbH, Deutsche Telekom AG
+ * (C) 2024, YOUR_NAME, Deutsche Telekom MMS GmbH, Deutsche Telekom AG
  *
  * Deutsche Telekom AG and all other contributors /
  * copyright owners license this file to you under the Apache


### PR DESCRIPTION
# Description

The StringAssertion interface is no longer inheriting from QuantityAssertion instead both of those interfaces now inherit ObjectAssertion which inherits BinaryAssertion. Also StringAssertion is now restricted to the type String. This is a breaking change since StringAssertion previously was able to use the functions of QuantityAssertion. Since these only worked on numbers this didn't make sense and triggered this change.

These functions moved from QuantityAssertion to ObjectAssertion so StringAssertion can still use them:
-     `boolean is(Object expected)`
-     `boolean is(Object expected, String subject)`
-     `boolean isNot(Object expected)`
-     `boolean isNot(Object expected, String subject)`

Some changes regarding generic types to remove related warnings have been added as well.

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
