### PR TITLE
Fix of failed Screenshot Test in report-ng-test

### DIFF
--- a/report-ng-tests/src/test/java/io/testerra/report/test/TestDataProvider.java
+++ b/report-ng-tests/src/test/java/io/testerra/report/test/TestDataProvider.java
@@ -278,6 +278,7 @@ public class TestDataProvider {
     public static Object[][] dataProviderMultipleScreenShotTests() {
         return new Object[][]{
                 {"test_takeScreenshotOnErrorWithMultipleActiveSessionsError", "GenerateScreenshotsInTesterraReportTest", ReportDetailsTab.class},
+                {"test_takeScreenshotViaCollectedAssertion_fails", "GenerateScreenshotsInTesterraReportTest", ReportDetailsTab.class},
                 {"test_takeScreenshotOnErrorWithMultipleExclusiveSessions", "GenerateScreenshotsInTesterraReportTest", ReportDetailsTab.class},
                 {"test_takeScreenshotsWithMultipleActiveSessions", "GenerateScreenshotsInTesterraReportTest", ReportStepsTab.class},
                 {"test_takeScreenshotWithMultipleExclusiveSessions", "GenerateScreenshotsInTesterraReportTest", ReportStepsTab.class},
@@ -288,7 +289,6 @@ public class TestDataProvider {
     public static Object[][] dataProviderSingleScreenShotTests() {
         return new Object[][]{
                 {"test_takeScreenshotOnExclusiveSession_fails", "GenerateScreenshotsInTesterraReportTest", ReportDetailsTab.class},
-                {"test_takeScreenshotViaCollectedAssertion_fails", "GenerateScreenshotsInTesterraReportTest", ReportDetailsTab.class},
                 {"test_takeExclusiveSessionScreenshotWithMultipleActiveSessions", "GenerateScreenshotsInTesterraReportTest", ReportStepsTab.class},
         };
     }


### PR DESCRIPTION
# Description

Fix of failing report test concerning screenshots of collected assertions. Test method test_multipleScreenshotsShown, which checks existence of multiple screenshots, now verifies this for test_takeScreenshotViaCollectedAssertion_fails, too.

Fixes issue #390

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ x] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] My changes generate no new warnings
- [ x] New and existing tests pass locally with my changes
- [x ] Any dependent changes have been merged and published in downstream modules
