### PR TITLE
Fix/element check timeout

### DIFF
--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/internal/action/GuiElementCheckFieldAction.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/internal/action/GuiElementCheckFieldAction.java
@@ -62,7 +62,8 @@ public class GuiElementCheckFieldAction extends AbstractCheckFieldAction {
 
         // Handling custom timeouts
         int useTimeout;
-        if (overrides.hasTimeout()) {
+        boolean threadLocalTimeoutSet = overrides.hasTimeout();
+        if (threadLocalTimeoutSet) {
             useTimeout = overrides.getTimeoutInSeconds();
         } else {
             useTimeout = check.timeout();
@@ -121,9 +122,16 @@ public class GuiElementCheckFieldAction extends AbstractCheckFieldAction {
             }
         }
 
-        if (prevTimeout >= 0) {
-            overrides.setTimeout(prevTimeout);
+        if (threadLocalTimeoutSet) {
+            if (prevTimeout >= 0) {
+                // Reset timeout to previous value
+                overrides.setTimeout(prevTimeout);
+            }
+        } else {
+            // Remove thread local timeout
+            overrides.setTimeout(-1);
         }
+
         if (check.optional() || check.collect()) {
             overrides.setAssertionImpl(previousAssertionImpl);
         }


### PR DESCRIPTION
# Description

If there were multiple UiElements with a `@Check` and a custom timeout for that check, only the first element was checked with that timeout, because after that, the threadLocalTimeout was set to the `tt.element.timeout.seconds` property, even though there should be no threadLocalTimeout.

**Example:**

Property set: `tt.element.timeout.seconds=10`

```
@Check(checkRule = CheckRule.IS_NOT_DISPLAYED, timeout = 1)
private final UiElement test = find(By.id("test"));
// -> check was done with a timeout of 1 seconds

@Check(checkRule = CheckRule.IS_NOT_DISPLAYED, timeout = 1)
private final UiElement test2 = find(By.id("test2"));
// -> check was done with a timeout of 10 seconds
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
