### PR TITLE
Feature/control api delay

### DIFF
--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/testing/DefaultTestController.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/testing/DefaultTestController.java
@@ -178,6 +178,18 @@ public class DefaultTestController implements TestController, Loggable {
         }
     }
 
+    @Override
+    public void delayGuiElementAction(int millisBefore, int millisAfter, Runnable runnable) {
+        int prevDelayBefore = overrides.setDelayBeforeAction(millisBefore);
+        int prevDelayAfter = overrides.setDelayAfterAction(millisAfter);
+        try {
+            runnable.run();
+        } finally {
+            overrides.setDelayBeforeAction(prevDelayBefore);
+            overrides.setDelayAfterAction(prevDelayAfter);
+        }
+    }
+
     private Throwable _waitTimes(int times, Assert.ThrowingRunnable runnable, BiConsumer<Integer, Throwable> whenFail) {
         Throwable catchedThrowable = null;
         for (int s = 0; s < times; ++s) {

--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/testing/DefaultTestController.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/testing/DefaultTestController.java
@@ -159,8 +159,8 @@ public class DefaultTestController implements TestController, Loggable {
     }
 
     @Override
-    public void withDelayAfterAction(int millis, Runnable runnable) {
-        int prevDelay = overrides.setDelayAfterAction(millis);
+    public void withDelayAfterAction(int seconds, Runnable runnable) {
+        int prevDelay = overrides.setDelayAfterAction(seconds);
         try {
             runnable.run();
         } finally {

--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/testing/DefaultTestController.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/testing/DefaultTestController.java
@@ -159,34 +159,12 @@ public class DefaultTestController implements TestController, Loggable {
     }
 
     @Override
-    public void delayBeforeGuiElementAction(int millis, Runnable runnable) {
-        int prevDelay = overrides.setDelayBeforeAction(millis);
-        try {
-            runnable.run();
-        } finally {
-            overrides.setDelayBeforeAction(prevDelay);
-        }
-    }
-
-    @Override
-    public void delayAfterGuiElementAction(int millis, Runnable runnable) {
+    public void withDelayAfterAction(int millis, Runnable runnable) {
         int prevDelay = overrides.setDelayAfterAction(millis);
         try {
             runnable.run();
         } finally {
             overrides.setDelayAfterAction(prevDelay);
-        }
-    }
-
-    @Override
-    public void delayGuiElementAction(int millisBefore, int millisAfter, Runnable runnable) {
-        int prevDelayBefore = overrides.setDelayBeforeAction(millisBefore);
-        int prevDelayAfter = overrides.setDelayAfterAction(millisAfter);
-        try {
-            runnable.run();
-        } finally {
-            overrides.setDelayBeforeAction(prevDelayBefore);
-            overrides.setDelayAfterAction(prevDelayAfter);
         }
     }
 

--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/testing/DefaultTestControllerOverrides.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/testing/DefaultTestControllerOverrides.java
@@ -27,11 +27,14 @@ import eu.tsystems.mms.tic.testframework.execution.testng.InstantAssertion;
 
 /**
  * Default implementation of {@link ThreadLocal} {@link TestController.Overrides}
+ *
  * @author Mike Reiche
  */
 public class DefaultTestControllerOverrides implements TestController.Overrides {
 
     private final ThreadLocal<Integer> threadLocalTimeout = new ThreadLocal<>();
+    private final ThreadLocal<Integer> threadLocalDelayBeforeAction = new ThreadLocal<>();
+    private final ThreadLocal<Integer> threadLocalDelayAfterAction = new ThreadLocal<>();
     private final ThreadLocal<Assertion> threadLocalAssertionImpl = new ThreadLocal<>();
 
     DefaultTestControllerOverrides() {
@@ -39,7 +42,17 @@ public class DefaultTestControllerOverrides implements TestController.Overrides 
 
     @Override
     public boolean hasTimeout() {
-        return threadLocalTimeout.get()!=null;
+        return threadLocalTimeout.get() != null;
+    }
+
+    @Override
+    public boolean hasDelayBeforeAction() {
+        return threadLocalDelayBeforeAction.get()!=null;
+    }
+
+    @Override
+    public boolean hasDelayAfterAction() {
+        return threadLocalDelayAfterAction.get() != null;
     }
 
     @Override
@@ -59,6 +72,44 @@ public class DefaultTestControllerOverrides implements TestController.Overrides 
             threadLocalTimeout.set(seconds);
         }
         return prevTimeout;
+    }
+
+    @Override
+    public int getDelayBeforeAction() {
+        Integer integer = threadLocalDelayBeforeAction.get();
+        if (integer == null) return -1;
+        else return integer;
+    }
+
+    @Override
+    public int setDelayBeforeAction(int millis) {
+        Integer prevDelay = getDelayBeforeAction();
+        if (millis < 0) {
+            // Back to default
+            threadLocalDelayBeforeAction.remove();
+        } else {
+            threadLocalDelayBeforeAction.set(millis);
+        }
+        return prevDelay;
+    }
+
+    @Override
+    public int getDelayAfterAction() {
+        Integer integer = threadLocalDelayAfterAction.get();
+        if (integer == null) return -1;
+        else return integer;
+    }
+
+    @Override
+    public int setDelayAfterAction(int millis) {
+        Integer prevDelay = getDelayAfterAction();
+        if (millis < 0) {
+            // Back to default
+            threadLocalDelayAfterAction.remove();
+        } else {
+            threadLocalDelayAfterAction.set(millis);
+        }
+        return prevDelay;
     }
 
     @Override

--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/testing/DefaultTestControllerOverrides.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/testing/DefaultTestControllerOverrides.java
@@ -33,7 +33,6 @@ import eu.tsystems.mms.tic.testframework.execution.testng.InstantAssertion;
 public class DefaultTestControllerOverrides implements TestController.Overrides {
 
     private final ThreadLocal<Integer> threadLocalTimeout = new ThreadLocal<>();
-    private final ThreadLocal<Integer> threadLocalDelayBeforeAction = new ThreadLocal<>();
     private final ThreadLocal<Integer> threadLocalDelayAfterAction = new ThreadLocal<>();
     private final ThreadLocal<Assertion> threadLocalAssertionImpl = new ThreadLocal<>();
 
@@ -43,11 +42,6 @@ public class DefaultTestControllerOverrides implements TestController.Overrides 
     @Override
     public boolean hasTimeout() {
         return threadLocalTimeout.get() != null;
-    }
-
-    @Override
-    public boolean hasDelayBeforeAction() {
-        return threadLocalDelayBeforeAction.get()!=null;
     }
 
     @Override
@@ -72,25 +66,6 @@ public class DefaultTestControllerOverrides implements TestController.Overrides 
             threadLocalTimeout.set(seconds);
         }
         return prevTimeout;
-    }
-
-    @Override
-    public int getDelayBeforeAction() {
-        Integer integer = threadLocalDelayBeforeAction.get();
-        if (integer == null) return -1;
-        else return integer;
-    }
-
-    @Override
-    public int setDelayBeforeAction(int millis) {
-        Integer prevDelay = getDelayBeforeAction();
-        if (millis < 0) {
-            // Back to default
-            threadLocalDelayBeforeAction.remove();
-        } else {
-            threadLocalDelayBeforeAction.set(millis);
-        }
-        return prevDelay;
     }
 
     @Override

--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/testing/DefaultTestControllerOverrides.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/testing/DefaultTestControllerOverrides.java
@@ -76,13 +76,13 @@ public class DefaultTestControllerOverrides implements TestController.Overrides 
     }
 
     @Override
-    public int setDelayAfterAction(int millis) {
+    public int setDelayAfterAction(int seconds) {
         Integer prevDelay = getDelayAfterAction();
-        if (millis < 0) {
+        if (seconds < 0) {
             // Back to default
             threadLocalDelayAfterAction.remove();
         } else {
-            threadLocalDelayAfterAction.set(millis);
+            threadLocalDelayAfterAction.set(seconds * 1000);
         }
         return prevDelay;
     }

--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/testing/TestController.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/testing/TestController.java
@@ -22,11 +22,11 @@
 package eu.tsystems.mms.tic.testframework.testing;
 
 import eu.tsystems.mms.tic.testframework.execution.testng.Assertion;
-import eu.tsystems.mms.tic.testframework.execution.testng.SimpleAssertion;
 import org.testng.Assert;
 
 /**
  * Allows to run blocks of code in a {@link Runnable} with {@link Overrides}
+ *
  * @author Mike Reiche
  */
 public interface TestController {
@@ -38,17 +38,55 @@ public interface TestController {
          * Determines if a timeout has been configured
          */
         boolean hasTimeout();
+
+        /**
+         * Determines if a delay before action has been configured
+         */
+        boolean hasDelayBeforeAction();
+
+        /**
+         * Determines if a delay before action has been configured
+         */
+        boolean hasDelayAfterAction();
+
         /**
          * @return Configured or default timeout for any actions
          */
         int getTimeoutInSeconds();
 
         /**
+         * @return Configured or default delay before actions
+         */
+        int getDelayBeforeAction();
+
+        /**
+         * @return Configured or default delay after actions
+         */
+        int getDelayAfterAction();
+
+        /**
          * Sets a timeout for any action
+         *
          * @param seconds If < 0, the timeout configuration will be removed
          * @return Returns the previously configured timeout
          */
         int setTimeout(int seconds);
+
+        /**
+         * Sets a delay before an action on a UiElement
+         *
+         * @param millis If < 0, the delay configuration will be removed
+         * @return Returns the previously configured delay
+         */
+        int setDelayBeforeAction(int millis);
+
+        /**
+         * Sets a delay after an action on a UiElement
+         *
+         * @param millis If < 0, the delay configuration will be removed
+         * @return Returns the previously configured delay
+         */
+        int setDelayAfterAction(int millis);
 
         Assertion getAssertionImpl();
 
@@ -71,7 +109,18 @@ public interface TestController {
     void withTimeout(int seconds, Runnable runnable);
 
     /**
+     * Runs a {@link Runnable} with a specified delay before actions
+     */
+    void delayBeforeGuiElementAction(int millis, Runnable runnable);
+
+    /**
+     * Runs a {@link Runnable} with a specified delay before actions
+     */
+    void delayAfterGuiElementAction(int millis, Runnable runnable);
+
+    /**
      * Runs a {@link Runnable} while {@link Throwable} occurs for a specified period.
+     *
      * @param seconds Period in seconds
      * @param runnable Runnable
      * @param whenFail Runnable which gets called when a throwable occurred
@@ -87,6 +136,7 @@ public interface TestController {
 
     /**
      * Runs a {@link Runnable} while {@link Throwable} occurs n times.
+     *
      * @param times Retry n times
      * @param runnable Runnable
      * @param whenFail Runnable which gets called when a throwable occurred
@@ -101,7 +151,7 @@ public interface TestController {
     }
 
     /**
-     * Does the same like {@link #retryFor(int, Assert.ThrowingRunnable, Runnable)} but without throwing any exception
+     * Does the same as {@link #retryFor(int, Assert.ThrowingRunnable, Runnable)} but without throwing any exception
      */
     boolean waitFor(int seconds, Assert.ThrowingRunnable runnable, Runnable whenFail);
 
@@ -113,7 +163,7 @@ public interface TestController {
     }
 
     /**
-     * Does the same like {@link #retryTimes(int, Assert.ThrowingRunnable, Runnable)} but without throwing any exception
+     * Does the same as {@link #retryTimes(int, Assert.ThrowingRunnable, Runnable)} but without throwing any exception
      */
     boolean waitTimes(int times, Assert.ThrowingRunnable runnable, Runnable whenFail);
 

--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/testing/TestController.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/testing/TestController.java
@@ -42,22 +42,12 @@ public interface TestController {
         /**
          * Determines if a delay before action has been configured
          */
-        boolean hasDelayBeforeAction();
-
-        /**
-         * Determines if a delay before action has been configured
-         */
         boolean hasDelayAfterAction();
 
         /**
          * @return Configured or default timeout for any actions
          */
         int getTimeoutInSeconds();
-
-        /**
-         * @return Configured or default delay before actions
-         */
-        int getDelayBeforeAction();
 
         /**
          * @return Configured or default delay after actions
@@ -71,14 +61,6 @@ public interface TestController {
          * @return Returns the previously configured timeout
          */
         int setTimeout(int seconds);
-
-        /**
-         * Sets a delay before an action on a UiElement
-         *
-         * @param millis If < 0, the delay configuration will be removed
-         * @return Returns the previously configured delay
-         */
-        int setDelayBeforeAction(int millis);
 
         /**
          * Sets a delay after an action on a UiElement
@@ -111,17 +93,7 @@ public interface TestController {
     /**
      * Runs a {@link Runnable} with a specified delay before actions
      */
-    void delayBeforeGuiElementAction(int millis, Runnable runnable);
-
-    /**
-     * Runs a {@link Runnable} with a specified delay before actions
-     */
-    void delayAfterGuiElementAction(int millis, Runnable runnable);
-
-    /**
-     * Runs a {@link Runnable} with a specified delay before and after actions
-     */
-    void delayGuiElementAction(int millisBefore, int millisAfter, Runnable runnable);
+    void withDelayAfterAction(int millis, Runnable runnable);
 
     /**
      * Runs a {@link Runnable} while {@link Throwable} occurs for a specified period.

--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/testing/TestController.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/testing/TestController.java
@@ -65,10 +65,10 @@ public interface TestController {
         /**
          * Sets a delay after actions on a UiElement
          *
-         * @param millis If < 0, the delay configuration will be removed
+         * @param seconds If < 0, the delay configuration will be removed
          * @return Returns the previously configured delay
          */
-        int setDelayAfterAction(int millis);
+        int setDelayAfterAction(int seconds);
 
         Assertion getAssertionImpl();
 
@@ -93,7 +93,7 @@ public interface TestController {
     /**
      * Runs a {@link Runnable} with a specified delay after actions
      */
-    void withDelayAfterAction(int millis, Runnable runnable);
+    void withDelayAfterAction(int seconds, Runnable runnable);
 
     /**
      * Runs a {@link Runnable} while {@link Throwable} occurs for a specified period.

--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/testing/TestController.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/testing/TestController.java
@@ -119,6 +119,11 @@ public interface TestController {
     void delayAfterGuiElementAction(int millis, Runnable runnable);
 
     /**
+     * Runs a {@link Runnable} with a specified delay before and after actions
+     */
+    void delayGuiElementAction(int millisBefore, int millisAfter, Runnable runnable);
+
+    /**
      * Runs a {@link Runnable} while {@link Throwable} occurs for a specified period.
      *
      * @param seconds Period in seconds

--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/testing/TestController.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/testing/TestController.java
@@ -40,7 +40,7 @@ public interface TestController {
         boolean hasTimeout();
 
         /**
-         * Determines if a delay before action has been configured
+         * Determines if a delay after actions has been configured
          */
         boolean hasDelayAfterAction();
 
@@ -63,7 +63,7 @@ public interface TestController {
         int setTimeout(int seconds);
 
         /**
-         * Sets a delay after an action on a UiElement
+         * Sets a delay after actions on a UiElement
          *
          * @param millis If < 0, the delay configuration will be removed
          * @return Returns the previously configured delay
@@ -91,7 +91,7 @@ public interface TestController {
     void withTimeout(int seconds, Runnable runnable);
 
     /**
-     * Runs a {@link Runnable} with a specified delay before actions
+     * Runs a {@link Runnable} with a specified delay after actions
      */
     void withDelayAfterAction(int millis, Runnable runnable);
 

--- a/docs/src/docs/execution/test-controller.adoc
+++ b/docs/src/docs/execution/test-controller.adoc
@@ -62,6 +62,17 @@ public void test_something_fast() {
 
 NOTE: `withTimeout()` overrides all internal timeouts except the explicit set timeout in `waitFor(int seconds)` methods.
 
+== Add delay after actions
+
+Adding a delay after an actions on UiElements can be achieved by overriding it for a specified block.
+
+[source, java]
+----
+CONTROL.withDelayAfterAction(500, () -> {
+    button.click(); // Delay of 500 milliseconds after the click
+});
+----
+
 == Retries
 
 In some situations you cannot rely on single assertions or waits anymore and need to continue trying something out before performing an alternative solution. Use control methods for repeating a couple of actions within a loop until a timeout has reached.

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/GuiElement.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/GuiElement.java
@@ -47,6 +47,7 @@ import eu.tsystems.mms.tic.testframework.pageobjects.internal.facade.UiElementLo
 import eu.tsystems.mms.tic.testframework.pageobjects.internal.waiters.DefaultGuiElementWait;
 import eu.tsystems.mms.tic.testframework.pageobjects.internal.waiters.GuiElementWait;
 import eu.tsystems.mms.tic.testframework.report.Report;
+import eu.tsystems.mms.tic.testframework.testing.TestController;
 import eu.tsystems.mms.tic.testframework.testing.WebDriverManagerProvider;
 import eu.tsystems.mms.tic.testframework.webdriver.WebDriverFactory;
 import org.openqa.selenium.By;
@@ -69,6 +70,8 @@ import java.util.stream.Collectors;
  * Authors: pele, rnhb
  */
 public class GuiElement implements UiElement, NameableChild<UiElement>, Loggable, WebDriverManagerProvider {
+
+    private final static TestController.Overrides overrides = Testerra.getInjector().getInstance(TestController.Overrides.class);
     /**
      * Factory required for {@link UiElementFinder}
      */
@@ -204,6 +207,14 @@ public class GuiElement implements UiElement, NameableChild<UiElement>, Loggable
 
         int delayAfterAction = Properties.DELAY_AFTER_ACTION_MILLIS.asLong().intValue();
         int delayBeforeAction = Properties.DELAY_BEFORE_ACTION_MILLIS.asLong().intValue();
+
+        if (overrides.hasDelayBeforeAction()) {
+            delayBeforeAction = overrides.getDelayBeforeAction();
+        }
+        if (overrides.hasDelayAfterAction()) {
+            delayAfterAction = overrides.getDelayAfterAction();
+        }
+
         if (delayAfterAction > 0 || delayBeforeAction > 0) {
             decoratedCore = new DelayActionsGuiElementFacade(decoratedCore, delayBeforeAction, delayAfterAction);
         }

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/GuiElement.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/GuiElement.java
@@ -47,7 +47,6 @@ import eu.tsystems.mms.tic.testframework.pageobjects.internal.facade.UiElementLo
 import eu.tsystems.mms.tic.testframework.pageobjects.internal.waiters.DefaultGuiElementWait;
 import eu.tsystems.mms.tic.testframework.pageobjects.internal.waiters.GuiElementWait;
 import eu.tsystems.mms.tic.testframework.report.Report;
-import eu.tsystems.mms.tic.testframework.testing.TestController;
 import eu.tsystems.mms.tic.testframework.testing.WebDriverManagerProvider;
 import eu.tsystems.mms.tic.testframework.webdriver.WebDriverFactory;
 import org.openqa.selenium.By;
@@ -71,7 +70,6 @@ import java.util.stream.Collectors;
  */
 public class GuiElement implements UiElement, NameableChild<UiElement>, Loggable, WebDriverManagerProvider {
 
-    private final static TestController.Overrides overrides = Testerra.getInjector().getInstance(TestController.Overrides.class);
     /**
      * Factory required for {@link UiElementFinder}
      */
@@ -196,7 +194,7 @@ public class GuiElement implements UiElement, NameableChild<UiElement>, Loggable
 
     /**
      * We cannot use the GuiElementFactory for decorating the facade here,
-     * since GuiElement is not always created by it's according factory
+     * since GuiElement is not always created by its according factory
      * and implementing a GuiElementFacadeFactory is useless.
      * You can move this code to DefaultGuiElementFactory when no more 'new GuiElement()' calls exists.
      */
@@ -208,16 +206,7 @@ public class GuiElement implements UiElement, NameableChild<UiElement>, Loggable
         int delayAfterAction = Properties.DELAY_AFTER_ACTION_MILLIS.asLong().intValue();
         int delayBeforeAction = Properties.DELAY_BEFORE_ACTION_MILLIS.asLong().intValue();
 
-        if (overrides.hasDelayBeforeAction()) {
-            delayBeforeAction = overrides.getDelayBeforeAction();
-        }
-        if (overrides.hasDelayAfterAction()) {
-            delayAfterAction = overrides.getDelayAfterAction();
-        }
-
-        if (delayAfterAction > 0 || delayBeforeAction > 0) {
-            decoratedCore = new DelayActionsGuiElementFacade(decoratedCore, delayBeforeAction, delayAfterAction);
-        }
+        decoratedCore = new DelayActionsGuiElementFacade(decoratedCore, delayBeforeAction, delayAfterAction);
     }
 
     /**

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/internal/facade/DelayActionsGuiElementFacade.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/internal/facade/DelayActionsGuiElementFacade.java
@@ -21,9 +21,11 @@
  */
 package eu.tsystems.mms.tic.testframework.pageobjects.internal.facade;
 
+import eu.tsystems.mms.tic.testframework.common.Testerra;
 import eu.tsystems.mms.tic.testframework.pageobjects.internal.core.AbstractGuiElementCoreDecorator;
 import eu.tsystems.mms.tic.testframework.pageobjects.internal.core.GuiElementCore;
 import eu.tsystems.mms.tic.testframework.pageobjects.internal.core.GuiElementCoreActions;
+import eu.tsystems.mms.tic.testframework.testing.TestController;
 import eu.tsystems.mms.tic.testframework.utils.TimerUtils;
 
 /**
@@ -31,6 +33,7 @@ import eu.tsystems.mms.tic.testframework.utils.TimerUtils;
  */
 public class DelayActionsGuiElementFacade extends AbstractGuiElementCoreDecorator {
 
+    private final static TestController.Overrides overrides = Testerra.getInjector().getInstance(TestController.Overrides.class);
     private final int beforeActionSleepTime;
     private final int afterActionSleepTime;
 
@@ -40,11 +43,22 @@ public class DelayActionsGuiElementFacade extends AbstractGuiElementCoreDecorato
         this.afterActionSleepTime = afterActionSleepTime;
     }
 
-    protected void beforeDelegation(String method, Object ... params) {
-        TimerUtils.sleep(beforeActionSleepTime);
+    protected void beforeDelegation(String method, Object... params) {
+        if (beforeActionSleepTime > 0) {
+            TimerUtils.sleep(beforeActionSleepTime);
+        }
     }
 
     protected void afterDelegation() {
-        TimerUtils.sleep(afterActionSleepTime);
+        if (overrides.hasDelayAfterAction()) {
+            int delay = overrides.getDelayAfterAction();
+            if (delay > 0) {
+                TimerUtils.sleep(delay);
+            }
+        } else {
+            if (afterActionSleepTime > 0) {
+                TimerUtils.sleep(afterActionSleepTime);
+            }
+        }
     }
 }

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/testing/UiElementOverrides.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/testing/UiElementOverrides.java
@@ -17,15 +17,6 @@ public class UiElementOverrides extends DefaultTestControllerOverrides {
     }
 
     @Override
-    public int getDelayBeforeAction() {
-        int delay = super.getDelayBeforeAction();
-        if (delay < 0) {
-            delay = UiElement.Properties.DELAY_BEFORE_ACTION_MILLIS.asLong().intValue();
-        }
-        return delay;
-    }
-
-    @Override
     public int getDelayAfterAction() {
         int delay = super.getDelayAfterAction();
         if (delay < 0) {

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/testing/UiElementOverrides.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/testing/UiElementOverrides.java
@@ -15,4 +15,22 @@ public class UiElementOverrides extends DefaultTestControllerOverrides {
         }
         return timeoutInSeconds;
     }
+
+    @Override
+    public int getDelayBeforeAction() {
+        int delay = super.getDelayBeforeAction();
+        if (delay < 0) {
+            delay = UiElement.Properties.DELAY_BEFORE_ACTION_MILLIS.asLong().intValue();
+        }
+        return delay;
+    }
+
+    @Override
+    public int getDelayAfterAction() {
+        int delay = super.getDelayAfterAction();
+        if (delay < 0) {
+            delay = UiElement.Properties.DELAY_AFTER_ACTION_MILLIS.asLong().intValue();
+        }
+        return delay;
+    }
 }


### PR DESCRIPTION
# Description

This PR adds a new method `withDelayAfterAction` to `CONTROL` api to provide a possibility to define a delay after actions on specific elements are performed.

**Example of usage:**

```
CONTROL.withDelayAfterAction(1, () -> {
    button.click(); // Delay of 1 second after the click
});
```

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
