### PR TITLE
Bump TestNG from 7.8.0 to 7.10.1

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     // -> Dependency error Could not find netty-transport-native-epoll-4.1.84.Final-linux-x86_64.jar (io.netty:netty-transport-native-epoll:4.1.84.Final).
     api 'org.seleniumhq.selenium:selenium-java:' + seleniumVersion
 
-    api('org.testng:testng:7.8.0')
+    api('org.testng:testng:7.10.1')
 
     // <FileUtils>
     implementation 'net.lingala.zip4j:zip4j:1.3.2'


### PR DESCRIPTION
# Description

Bump TestNG from 7.8.0 to 7.10.1

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
