### PR TITLE
Feature/layout check pixel count assertion

### DIFF
--- a/docs/src/docs/modules/layout-check.adoc
+++ b/docs/src/docs/modules/layout-check.adoc
@@ -19,11 +19,11 @@ A layout test with the Testerra utilities is actually a comparison between a ref
 image::layoutcheck_comparison.png[alt="Visualization of a layout check",width=920,height=233]
 
 There are two different ways in which Testerra handles different sized images.
-Using the property `tt.layoutcheck.pixel.count.assertion`, you can customize the handling of such cases.
+Using the property `{layoutcheck_pixel_count_hard_assertion}`, you can customize the handling of such cases.
 
-If the property is set to `optional` (default) Testerra reports this as an <<#_optional_assertions, Optional assertion>>. Only the common pixels of both images as considered as 100% for the calculation. Pixels that are outside of one or the other image are not included in the error calculation.
+If the property is set to `false` (default) Testerra reports this as an <<#_optional_assertions, Optional assertion>>. Only the common pixels of both images as considered as 100% for the calculation. Pixels that are outside of one or the other image are not included in the error calculation.
 
-With the property set to `hard`, the size difference of the two images is included in the calculation so that all pixels that appear in only one image counted as incorrect ones.
+With the property set to `true`, the size difference of the two images is included in the calculation so that all pixels that appear in only one image counted as incorrect ones.
 
 In both scenarios, all pixels outside one or the other image are marked in blue in the generated distance image.
 

--- a/docs/src/docs/modules/layout-check.adoc
+++ b/docs/src/docs/modules/layout-check.adoc
@@ -18,7 +18,14 @@ A layout test with the Testerra utilities is actually a comparison between a ref
 
 image::layoutcheck_comparison.png[alt="Visualization of a layout check",width=920,height=233]
 
-In case that one image has a different size than the other Testerra reports this as an <<#_optional_assertions, Optional assertion>>. Testerra considers only the common pixels of both images as 100%. Pixels that are outside of one or the other image are not included in the error calculation. In the comparison, those Pixels are marked in blue.
+There are two different ways in which Testerra handles different sized images.
+Using the property `tt.layoutcheck.pixel.count.assertion`, you can customize the handling of such cases.
+
+If the property is set to `optional` (default) Testerra reports this as an <<#_optional_assertions, Optional assertion>>. Only the common pixels of both images as considered as 100% for the calculation. Pixels that are outside of one or the other image are not included in the error calculation.
+
+With the property set to `hard`, the size difference of the two images is included in the calculation so that all pixels that appear in only one image counted as incorrect ones.
+
+In both scenarios, all pixels outside one or the other image are marked in blue in the generated distance image.
 
 image::layoutcheck_diffsize_comparison.png[alt="Visualization of a layout check with different sized images",width=920,height=233]
 

--- a/docs/src/docs/properties/layout-check-probs.adoc
+++ b/docs/src/docs/properties/layout-check-probs.adoc
@@ -15,7 +15,7 @@ include::property-attributes.adoc[]
 | {layoutcheck_distance_path} | `src/test/resources/screenreferences/distance` | Directory path under which the calculated distance images are stored.
 | {layoutcheck_actual_path}       | `src/test/resources/screenreferences/actual` | Directory path under which the current screenshots for the comparison are saved
 | {layoutcheck_pixel_rgb_deviation_percent}       | 0.0 | Max allowed difference in rgb values between actual and reference image in percentage. If on of Red, Green, and Blue percentages are higher than the given value, the corresponding pixel is marked as false (means red color in distance image)
-| {layoutcheck_pixel_count_assertion}    | optional | Specifies the handling of different sized images. Can be set to "optional" (only the common pixels of both images are used for the error calculation, pixels that are outside one of the images are ignored) or "hard" (the pixels outside of one or the other image are included in the error calculation and are counted as incorrect pixels).
+| {layoutcheck_pixel_count_hard_assertion}    | false | Specifies the handling of different sized images. If false, only the common pixels of both images are used for the error calculation and pixels that are outside one of the images are ignored. If true, the pixels outside of one or the other image are included in the error calculation and are counted as incorrect pixels.
 
 // The following properties were used for annotated layout check, which is inactive
 //| {layoutcheck_match_threshold}       | 0.95d | Defines how many percent of pixels are considered a match. Should be as high as possible and as low as needed.

--- a/docs/src/docs/properties/layout-check-probs.adoc
+++ b/docs/src/docs/properties/layout-check-probs.adoc
@@ -15,6 +15,7 @@ include::property-attributes.adoc[]
 | {layoutcheck_distance_path} | `src/test/resources/screenreferences/distance` | Directory path under which the calculated distance images are stored.
 | {layoutcheck_actual_path}       | `src/test/resources/screenreferences/actual` | Directory path under which the current screenshots for the comparison are saved
 | {layoutcheck_pixel_rgb_deviation_percent}       | 0.0 | Max allowed difference in rgb values between actual and reference image in percentage. If on of Red, Green, and Blue percentages are higher than the given value, the corresponding pixel is marked as false (means red color in distance image)
+| {layoutcheck_pixel_count_assertion}    | optional | Specifies the handling of different sized images. Can be set to "optional" (only the common pixels of both images are used for the error calculation, pixels that are outside one of the images are ignored) or "hard" (the pixels outside of one or the other image are included in the error calculation and are counted as incorrect pixels).
 
 // The following properties were used for annotated layout check, which is inactive
 //| {layoutcheck_match_threshold}       | 0.95d | Defines how many percent of pixels are considered a match. Should be as high as possible and as low as needed.

--- a/docs/src/docs/properties/property-attributes.adoc
+++ b/docs/src/docs/properties/property-attributes.adoc
@@ -79,6 +79,7 @@
 :layoutcheck_distance_path:                     tt.layoutcheck.distance.path
 :layoutcheck_actual_path:                       tt.layoutcheck.actual.path
 :layoutcheck_pixel_rgb_deviation_percent:       tt.layoutcheck.pixel.rgb.deviation.percent
+:layoutcheck_pixel_count_assertion:             tt.layoutcheck.pixel.count.assertion
 
 :layoutcheck_match_threshold:                   tt.layoutcheck.match.threshold
 :layoutcheck_displacement_threshold:            tt.layoutcheck.displacement.threshold

--- a/docs/src/docs/properties/property-attributes.adoc
+++ b/docs/src/docs/properties/property-attributes.adoc
@@ -78,7 +78,7 @@
 :layoutcheck_distance_path:                     tt.layoutcheck.distance.path
 :layoutcheck_actual_path:                       tt.layoutcheck.actual.path
 :layoutcheck_pixel_rgb_deviation_percent:       tt.layoutcheck.pixel.rgb.deviation.percent
-:layoutcheck_pixel_count_assertion:             tt.layoutcheck.pixel.count.assertion
+:layoutcheck_pixel_count_hard_assertion:        tt.layoutcheck.pixel.count.hard.assertion
 
 :layoutcheck_match_threshold:                   tt.layoutcheck.match.threshold
 :layoutcheck_displacement_threshold:            tt.layoutcheck.displacement.threshold

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/layout/LayoutCheck.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/layout/LayoutCheck.java
@@ -72,7 +72,7 @@ public final class LayoutCheck implements PropertyManagerProvider, AssertProvide
         ACTUAL_PATH("actual.path", "src/test/resources/screenreferences/actual"),
         USE_IGNORE_COLOR("use.ignore.color", false),
         PIXEL_RGB_DEVIATION_PERCENT("pixel.rgb.deviation.percent", 0.0),
-        PIXEL_COUNT_ASSERTION("pixel.count.assertion", "optional"),
+        PIXEL_COUNT_HARD_ASSERTION("pixel.count.hard.assertion", false),
 
         ;
         private final String property;
@@ -256,7 +256,7 @@ public final class LayoutCheck implements PropertyManagerProvider, AssertProvide
 
     /**
      * Creates an image showing the differences of the given images and calculates the difference between the images in
-     * percent. Also calculates the percentage of pixels that are incorrect based on the property 'tt.layoutcheck.pixel.count.assertion'.
+     * percent. Also calculates the percentage of pixels that are incorrect based on the property 'tt.layoutcheck.pixel.count.hard.assertion'.
      *
      * @param expectedImage The expected image
      * @param actualImage The actual image
@@ -343,7 +343,8 @@ public final class LayoutCheck implements PropertyManagerProvider, AssertProvide
         double result_size = ((double) noOfExclusivePixels / totalPixels) * 100;
         double result = result_rgb;
 
-        if (Properties.PIXEL_COUNT_ASSERTION.asString().equalsIgnoreCase("hard")) {
+        boolean pixelCountHardAssertion = Properties.PIXEL_COUNT_HARD_ASSERTION.asBool();
+        if (pixelCountHardAssertion) {
             result += result_size;
         }
 

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/layout/LayoutCheck.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/layout/LayoutCheck.java
@@ -256,7 +256,7 @@ public final class LayoutCheck implements PropertyManagerProvider, AssertProvide
 
     /**
      * Creates an image showing the differences of the given images and calculates the difference between the images in
-     * percent.
+     * percent. Also calculates the percentage of pixels that are incorrect based on the property 'tt.layoutcheck.pixel.count.assertion'.
      *
      * @param expectedImage The expected image
      * @param actualImage The actual image

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/layout/LayoutCheck.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/layout/LayoutCheck.java
@@ -72,7 +72,7 @@ public final class LayoutCheck implements PropertyManagerProvider, AssertProvide
         ACTUAL_PATH("actual.path", "src/test/resources/screenreferences/actual"),
         USE_IGNORE_COLOR("use.ignore.color", false),
         PIXEL_RGB_DEVIATION_PERCENT("pixel.rgb.deviation.percent", 0.0),
-        PIXEL_COUNT("pixel.count", "optional"),
+        PIXEL_COUNT_ASSERTION("pixel.count.assertion", "optional"),
 
         ;
         private final String property;
@@ -343,7 +343,7 @@ public final class LayoutCheck implements PropertyManagerProvider, AssertProvide
         double result_size = ((double) noOfExclusivePixels / totalPixels) * 100;
         double result = result_rgb;
 
-        if (Properties.PIXEL_COUNT.asString().equalsIgnoreCase("hard")) {
+        if (Properties.PIXEL_COUNT_ASSERTION.asString().equalsIgnoreCase("hard")) {
             result += result_size;
         }
 

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/layout/LayoutCheck.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/layout/LayoutCheck.java
@@ -338,7 +338,6 @@ public final class LayoutCheck implements PropertyManagerProvider, AssertProvide
 
         int totalPixels = distanceImageSize.width * distanceImageSize.height;
 
-        // TODO: calculation
         // calculate and return the percentage number of pixels in error
         double result_rgb = ((double) pixelsInError / (totalPixels - noOfExclusivePixels - noOfIgnoredPixels)) * 100;
         double result_size = ((double) noOfExclusivePixels / totalPixels) * 100;
@@ -351,7 +350,7 @@ public final class LayoutCheck implements PropertyManagerProvider, AssertProvide
         // Just for debug log
         Dimension expectedImageDimension = new Dimension(expectedImage.getWidth(), expectedImage.getHeight());
         Dimension actualImageDimension = new Dimension(actualImage.getWidth(), actualImage.getHeight());
-        LOGGER.info("Raw results of pixel check: \n" +
+        LOGGER.debug("Raw results of pixel check: \n" +
                         "Dimension actual image: {}\n" +
                         "Dimension expected image: {}\n" +
                         "Number of total pixel: {}\n" +
@@ -452,8 +451,6 @@ public final class LayoutCheck implements PropertyManagerProvider, AssertProvide
                 // LayoutCheckContext (for dimension check and for pixel check) is working with identical objects
                 methodContext.addLayoutCheckContext(context.clone());
             });
-
-            // TODO: assertion
             OptionalAssert.fail(
                     String.format(
                             "The actual image (width=%dpx, height=%dpx) has a different size than the reference image (width=%dpx, height=%dpx)",

--- a/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/layoutcheck/LayoutCheckImageTest.java
+++ b/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/layoutcheck/LayoutCheckImageTest.java
@@ -59,7 +59,7 @@ public class LayoutCheckImageTest extends AbstractTestSitesTest implements Locat
 
     @Test(expectedExceptions = AssertionError.class)
     public void testT03_CheckImageLayoutDifferentSizes_Hard() {
-        PROPERTY_MANAGER.setTestLocalProperty("tt.layoutcheck.pixel.count.assertion", "hard");
+        PROPERTY_MANAGER.setTestLocalProperty("tt.layoutcheck.pixel.count.hard.assertion", true);
 
         UiElement uiElement = getUIElementQa("testimage");
         uiElement.expect().screenshot().pixelDistance("TestImageDifferentSize").isLowerThan(1.4);

--- a/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/layoutcheck/LayoutCheckImageTest.java
+++ b/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/layoutcheck/LayoutCheckImageTest.java
@@ -52,13 +52,13 @@ public class LayoutCheckImageTest extends AbstractTestSitesTest implements Locat
     }
 
     @Test
-    public void testT02_CheckImageLayoutDifferentSizesOptional() {
+    public void testT02_CheckImageLayoutDifferentSizes_Optional() {
         UiElement uiElement = getUIElementQa("testimage");
         uiElement.expect().screenshot().pixelDistance("TestImageDifferentSize").isLowerThan(1.4);
     }
 
     @Test(expectedExceptions = AssertionError.class)
-    public void testT03_CheckImageLayoutDifferentSizesHard() {
+    public void testT03_CheckImageLayoutDifferentSizes_Hard() {
         PROPERTY_MANAGER.setTestLocalProperty("tt.layoutcheck.pixel.count.assertion", "hard");
 
         UiElement uiElement = getUIElementQa("testimage");

--- a/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/layoutcheck/LayoutCheckImageTest.java
+++ b/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/layoutcheck/LayoutCheckImageTest.java
@@ -28,6 +28,8 @@ import eu.tsystems.mms.tic.testframework.pageobjects.LocatorFactoryProvider;
 import eu.tsystems.mms.tic.testframework.pageobjects.UiElement;
 import org.testng.annotations.Test;
 
+import static eu.tsystems.mms.tic.testframework.common.PropertyManagerProvider.PROPERTY_MANAGER;
+
 public class LayoutCheckImageTest extends AbstractTestSitesTest implements LocatorFactoryProvider {
 
     @Override
@@ -50,7 +52,15 @@ public class LayoutCheckImageTest extends AbstractTestSitesTest implements Locat
     }
 
     @Test
-    public void testT02_CheckImageLayoutDifferentSizes() {
+    public void testT02_CheckImageLayoutDifferentSizesOptional() {
+        UiElement uiElement = getUIElementQa("testimage");
+        uiElement.expect().screenshot().pixelDistance("TestImageDifferentSize").isLowerThan(1.4);
+    }
+
+    @Test(expectedExceptions = AssertionError.class)
+    public void testT03_CheckImageLayoutDifferentSizesHard() {
+        PROPERTY_MANAGER.setTestLocalProperty("tt.layoutcheck.pixel.count.assertion", "hard");
+
         UiElement uiElement = getUIElementQa("testimage");
         uiElement.expect().screenshot().pixelDistance("TestImageDifferentSize").isLowerThan(1.4);
     }

--- a/integration-tests/src/test/resources/test.properties
+++ b/integration-tests/src/test/resources/test.properties
@@ -16,7 +16,7 @@ tt.report.screencaster.active=false
 tt.layoutcheck.reference.path=src/test/resources/layout-references/{tt.browser}
 tt.layoutcheck.reference.nametemplate=%s.png
 tt.layoutcheck.pixel.rgb.deviation.percent=4.5
-tt.layoutcheck.pixel.count.assertion=optional
+tt.layoutcheck.pixel.count.hard.assertion=false
 
 tt.failed.tests.if.throwable.classes=java.sql.SQLRecoverableException
 tt.failed.tests.if.throwable.messages=RetryUnderTest,test_FailedToPassedHistoryWithRetry,test_T08_RetriedDataProvider

--- a/integration-tests/src/test/resources/test.properties
+++ b/integration-tests/src/test/resources/test.properties
@@ -16,6 +16,7 @@ tt.report.screencaster.active=false
 tt.layoutcheck.reference.path=src/test/resources/layout-references/{tt.browser}
 tt.layoutcheck.reference.nametemplate=%s.png
 tt.layoutcheck.pixel.rgb.deviation.percent=4.5
+tt.layoutcheck.pixel.count.assertion=optional
 
 tt.failed.tests.if.throwable.classes=java.sql.SQLRecoverableException
 tt.failed.tests.if.throwable.messages=RetryUnderTest,test_FailedToPassedHistoryWithRetry,test_T08_RetriedDataProvider

--- a/integration-tests/src/test/resources/test.properties
+++ b/integration-tests/src/test/resources/test.properties
@@ -16,7 +16,6 @@ tt.report.screencaster.active=false
 tt.layoutcheck.reference.path=src/test/resources/layout-references/{tt.browser}
 tt.layoutcheck.reference.nametemplate=%s.png
 tt.layoutcheck.pixel.rgb.deviation.percent=4.5
-tt.layoutcheck.pixel.count=optional
 
 tt.failed.tests.if.throwable.classes=java.sql.SQLRecoverableException
 tt.failed.tests.if.throwable.messages=RetryUnderTest,test_FailedToPassedHistoryWithRetry,test_T08_RetriedDataProvider

--- a/integration-tests/src/test/resources/test.properties
+++ b/integration-tests/src/test/resources/test.properties
@@ -16,6 +16,7 @@ tt.report.screencaster.active=false
 tt.layoutcheck.reference.path=src/test/resources/layout-references/{tt.browser}
 tt.layoutcheck.reference.nametemplate=%s.png
 tt.layoutcheck.pixel.rgb.deviation.percent=4.5
+tt.layoutcheck.pixel.count=optional
 
 tt.failed.tests.if.throwable.classes=java.sql.SQLRecoverableException
 tt.failed.tests.if.throwable.messages=RetryUnderTest,test_FailedToPassedHistoryWithRetry,test_T08_RetriedDataProvider


### PR DESCRIPTION
# Description

This PR provides a new way to handle different sized images when using layout check by setting a property. This way the user has control over how these cases are handled.

The new property `tt.layoutcheck.pixel.count.hard.assertion` can be set to:
- `false` (default and also the current way this case is handled) for primarly checking rgb difference and doing an optional assertion for different sized images
- `true` for adding the size difference percentage to the rgb deviation for a combined check

**Example**

Image with 5% rgb deviation and 10% size difference
- `false` (optional): result = 5%
- `true` (hard): result = 5% + 10% = 15%

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
