### PR TITLE
Fixes bug #421 - Run Testerra as part of fat jar standalone application

### DIFF
--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/common/Testerra.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/common/Testerra.java
@@ -47,6 +47,7 @@ import org.apache.logging.log4j.core.config.Configurator;
 import org.apache.logging.log4j.core.config.DefaultConfiguration;
 import org.reflections.Reflections;
 import org.reflections.util.ConfigurationBuilder;
+import org.reflections.util.FilterBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -171,7 +172,10 @@ public class Testerra {
      * overwrite custom implementations (of factories, providers etc.) but custom modules can do this to inject their own behaviour.
      */
     private static Injector initIoc() {
-        Reflections reflections = new Reflections(new ConfigurationBuilder().forPackages(TesterraListener.DEFAULT_PACKAGES));
+        FilterBuilder filterBuilder = new FilterBuilder();
+        filterBuilder.includePackage(TesterraListener.DEFAULT_PACKAGES);
+
+        Reflections reflections = new Reflections(new ConfigurationBuilder().forPackages(TesterraListener.DEFAULT_PACKAGES).filterInputsBy(filterBuilder));
         Set<Class<? extends AbstractModule>> classes = reflections.getSubTypesOf(AbstractModule.class);
         Iterator<Class<? extends AbstractModule>> iterator = classes.iterator();
         TreeMap<String, Module> sortedModules = new TreeMap<>(new ModuleComparator());


### PR DESCRIPTION
# Description

Fixes bug #421 by apply a package filter to avoid implementations of `com.google.inject.AbstractModule` that does not fullfill package class will be instantiated.

Concrete class of the fat jar that will force this error is `com.google.inject.util.Modules$OverrideModule`.

Before this fix Testerra tried to invoke the following implementations of `AbstractModule` inside the fat jar:

* Loading module: eu.tsystems.mms.tic.testframework.hook.ReportModelHook
* Loading module: eu.tsystems.mms.tic.testframework.hook.ReportNgHook
* Loading module: com.google.inject.util.Modules$OverrideModule
* Loading module: eu.tsystems.mms.tic.testframework.ioc.CoreHook
* Loading module: com.google.inject.internal.RealMultibinder$PermitDuplicatesModule
* Loading module: eu.tsystems.mms.tic.testframework.hooks.DriverUiHook
* Loading module: eu.tsystems.mms.tic.testframework.ioc.DriverUi_Desktop
* Loading module: com.google.inject.assistedinject.FactoryProvider2$2
* Loading module: com.google.inject.assistedinject.FactoryModuleBuilder$1
* Loading module: com.google.inject.util.Modules$2

After this fix Testerra tried to invoke the following implemenation like intended:
* Loading module: eu.tsystems.mms.tic.testframework.hook.ReportModelHook
* Loading module: eu.tsystems.mms.tic.testframework.hook.ReportNgHook
* Loading module: eu.tsystems.mms.tic.testframework.ioc.CoreHook
* Loading module: eu.tsystems.mms.tic.testframework.hooks.DriverUiHook
* Loading module: eu.tsystems.mms.tic.testframework.ioc.DriverUi_Desktop


Fixes #421

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
