### PR TITLE
Revert "Updated Gson builder in ContextExporter"

### DIFF
--- a/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/webdrivermanager/DesktopWebDriverFactoryTest.java
+++ b/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/webdrivermanager/DesktopWebDriverFactoryTest.java
@@ -32,11 +32,9 @@ import eu.tsystems.mms.tic.testframework.useragents.ChromeConfig;
 import eu.tsystems.mms.tic.testframework.webdrivermanager.DesktopWebDriverRequest;
 import eu.tsystems.mms.tic.testframework.webdrivermanager.WebDriverRequest;
 import org.openqa.selenium.By;
-import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.Platform;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
-import org.openqa.selenium.logging.LoggingPreferences;
 import org.openqa.selenium.remote.CapabilityType;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.testng.Assert;
@@ -177,20 +175,6 @@ public class DesktopWebDriverFactoryTest extends TesterraTest implements WebDriv
         String content = chromeExtensionJson.waitFor().text().getActual();
         Assert.assertTrue(content.contains("Simple Translate"));
 
-    }
-
-    /**
-     * This test generates special caps to test a successful export of all test context in `ContextExporter`.
-     * If a report of all integration tests is generated this test has no impact.
-     * https://github.com/telekom/testerra/issues/409
-     */
-    @Test
-    public void testT09_SpecialCapsForContextExport() {
-        DesktopWebDriverRequest request = new DesktopWebDriverRequest();
-        MutableCapabilities capabilities = request.getMutableCapabilities();
-        LoggingPreferences logPrefs = new LoggingPreferences();
-        capabilities.setCapability("goog:loggingPrefs", logPrefs);
-        WEB_DRIVER_MANAGER.getWebDriver(request);
     }
 
 }

--- a/report-model/src/main/java/eu/tsystems/mms/tic/testframework/adapters/ContextExporter.java
+++ b/report-model/src/main/java/eu/tsystems/mms/tic/testframework/adapters/ContextExporter.java
@@ -23,7 +23,6 @@ package eu.tsystems.mms.tic.testframework.adapters;
 
 import com.google.common.net.MediaType;
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.google.inject.Injector;
 import eu.tsystems.mms.tic.testframework.common.Testerra;
 import eu.tsystems.mms.tic.testframework.internal.IdGenerator;
@@ -72,7 +71,6 @@ import eu.tsystems.mms.tic.testframework.report.utils.IExecutionContextControlle
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Level;
 
-import java.lang.reflect.Modifier;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Date;
@@ -91,7 +89,7 @@ public class ContextExporter implements Loggable {
     private final Map<Status, ResultStatusType> RESULT_STATUS_MAPPING = new LinkedHashMap<>();
     private final Map<Class, FailureCorridorValue> FAILURE_CORRIDOR_MAPPING = new LinkedHashMap<>();
     private final Report report = injector.getInstance(Report.class);
-    private final Gson jsonEncoder = new GsonBuilder().excludeFieldsWithModifiers(Modifier.PRIVATE).create();
+    private final Gson jsonEncoder = new Gson();
 
     public MethodContext.Builder buildMethodContext(eu.tsystems.mms.tic.testframework.report.model.context.MethodContext methodContext) {
         MethodContext.Builder builder = MethodContext.newBuilder();


### PR DESCRIPTION
Reverts telekom/testerra#418

Need a new fix. The current solution eliminate all caps for report.