### PR TITLE
added class filter for threads view

### DIFF
--- a/report-ng/app/src/components/threads/threads.html
+++ b/report-ng/app/src/components/threads/threads.html
@@ -25,10 +25,11 @@
         <mdc-layout-grid-inner>
             <mdc-layout-grid-cell span="2">
                 <mdc-select label="Status"
-                            value.bind="_selectedStatus"
+                            value.bind="queryParams.status"
                             change.delegate="_statusChanged()"
                             outlined
                             class="w100"
+                            disabled.bind="queryParams.class || queryParams.methodId"
                 >
                     <mdc-list>
                         <mdc-list-item>(All)</mdc-list-item>
@@ -42,10 +43,11 @@
             </mdc-layout-grid-cell>
             <mdc-layout-grid-cell span="3">
                 <mdc-select label="Class"
-                            value.bind="_selectedClass"
+                            value.bind="queryParams.class"
                             change.delegate="_classChanged()"
                             outlined
                             class="w100"
+                            disabled.bind="queryParams.status || queryParams.methodId"
                 >
                     <mdc-list>
                         <mdc-list-item>(All)</mdc-list-item>
@@ -64,7 +66,11 @@
                                         class="w100"
                                         value.bind="_inputValue"
                                         input.delegate="_selectionChanged()"
+                                        disabled.bind="queryParams.status || queryParams.class || _suppressMethodFilter"
                         >
+                            <button mdc-icon-button mdc-text-field-icon trailing icon="close" tabindex="0"
+                                    if.bind="queryParams.methodId"
+                                    click.delegate="_removeMethodFilter()"></button>
                         </mdc-text-field>
                         <mdc-text-field-helper-line></mdc-text-field-helper-line>
                         <mdc-lookup options.bind="_getLookupOptions"

--- a/report-ng/app/src/components/threads/threads.html
+++ b/report-ng/app/src/components/threads/threads.html
@@ -25,6 +25,7 @@
         <mdc-layout-grid-inner>
             <mdc-layout-grid-cell span="2">
                 <mdc-select label="Status"
+                            ref="statusSelect"
                             value.bind="_selectedStatus"
                             change.delegate="_statusChanged()"
                             outlined
@@ -43,6 +44,7 @@
             </mdc-layout-grid-cell>
             <mdc-layout-grid-cell span="3">
                 <mdc-select label="Class"
+                            ref="classSelect"
                             value.bind="_selectedClass"
                             change.delegate="_classChanged()"
                             outlined

--- a/report-ng/app/src/components/threads/threads.html
+++ b/report-ng/app/src/components/threads/threads.html
@@ -66,11 +66,8 @@
                                         class="w100"
                                         value.bind="_inputValue"
                                         input.delegate="_selectionChanged()"
-                                        disabled.bind="queryParams.status || queryParams.class || _suppressMethodFilter"
+                                        disabled.bind="queryParams.status || queryParams.class"
                         >
-                            <button mdc-icon-button mdc-text-field-icon trailing icon="close" tabindex="0"
-                                    if.bind="queryParams.methodId"
-                                    click.delegate="_removeMethodFilter()"></button>
                         </mdc-text-field>
                         <mdc-text-field-helper-line></mdc-text-field-helper-line>
                         <mdc-lookup options.bind="_getLookupOptions"

--- a/report-ng/app/src/components/threads/threads.html
+++ b/report-ng/app/src/components/threads/threads.html
@@ -40,7 +40,22 @@
                     </mdc-list>
                 </mdc-select>
             </mdc-layout-grid-cell>
-            <mdc-layout-grid-cell span="4">
+            <mdc-layout-grid-cell span="3">
+                <mdc-select label="Class"
+                            value.bind="_selectedClass"
+                            change.delegate="_classChanged()"
+                            outlined
+                            class="w100"
+                >
+                    <mdc-list>
+                        <mdc-list-item>(All)</mdc-list-item>
+                        <mdc-list-item repeat.for="classStatistic of _executionStatistics.classStatistics"
+                                       value.bind="classStatistic.classIdentifier"
+                        >${classStatistic.classIdentifier|className:1}</mdc-list-item>
+                    </mdc-list>
+                </mdc-select>
+            </mdc-layout-grid-cell>
+            <mdc-layout-grid-cell span="5">
                 <div mdc-menu-surface-anchor>
                     <mdc-card-action-textfield>
                         <mdc-text-field label="Method"

--- a/report-ng/app/src/components/threads/threads.html
+++ b/report-ng/app/src/components/threads/threads.html
@@ -25,11 +25,11 @@
         <mdc-layout-grid-inner>
             <mdc-layout-grid-cell span="2">
                 <mdc-select label="Status"
-                            value.bind="queryParams.status"
+                            value.bind="_selectedStatus"
                             change.delegate="_statusChanged()"
                             outlined
                             class="w100"
-                            disabled.bind="queryParams.class || queryParams.methodId"
+                            disabled.bind="_selectedClass|| queryParams.class || queryParams.methodId"
                 >
                     <mdc-list>
                         <mdc-list-item>(All)</mdc-list-item>
@@ -43,11 +43,11 @@
             </mdc-layout-grid-cell>
             <mdc-layout-grid-cell span="3">
                 <mdc-select label="Class"
-                            value.bind="queryParams.class"
+                            value.bind="_selectedClass"
                             change.delegate="_classChanged()"
                             outlined
                             class="w100"
-                            disabled.bind="queryParams.status || queryParams.methodId"
+                            disabled.bind="_selectedStatus || queryParams.status || queryParams.methodId"
                 >
                     <mdc-list>
                         <mdc-list-item>(All)</mdc-list-item>
@@ -66,7 +66,7 @@
                                         class="w100"
                                         value.bind="_inputValue"
                                         input.delegate="_selectionChanged()"
-                                        disabled.bind="queryParams.status || queryParams.class"
+                                        disabled.bind="_selectedStatus || _selectedClass || queryParams.status || queryParams.class"
                         >
                         </mdc-text-field>
                         <mdc-text-field-helper-line></mdc-text-field-helper-line>

--- a/report-ng/app/src/components/threads/threads.ts
+++ b/report-ng/app/src/components/threads/threads.ts
@@ -82,7 +82,6 @@ export class Threads extends AbstractViewModel {
 
     activate(params: any, routeConfig: RouteConfig, navInstruction: NavigationInstruction) {
         super.activate(params, routeConfig, navInstruction);
-        console.log("queryparams", this.queryParams)
         this._router = navInstruction.router;
 
         this._statisticsGenerator.getExecutionStatistics().then(executionStatistics => {
@@ -192,14 +191,6 @@ export class Threads extends AbstractViewModel {
             this._resetZoom();
             this.queryParams = {};
         }
-        console.log("queryparams(status)", this.queryParams)
-        if(this.queryParams.status){
-            console.log("log: status")
-        }
-        if(this.queryParams.class){
-            console.log("log: class")
-        }
-
     }
 
     private _classChanged() {
@@ -225,7 +216,6 @@ export class Threads extends AbstractViewModel {
             this._resetZoom();
             this.queryParams = {};
         }
-        console.log("queryparams(class)", this.queryParams)
     }
 
     private _zoom(zoomStart: number, zoomEnd: number) {
@@ -470,17 +460,5 @@ export class Threads extends AbstractViewModel {
 
     private _handleClickEvent(event: echarts.ECElementEvent) {
         this._router.navigateToRoute('method', {methodId: event.value[6]})
-    }
-
-    private _removeMethodFilter(){
-        delete this.queryParams.methodId;
-        this._inputValue = "";
-
-        this._searchRegexp = null;
-        if (this._filterActive && this.queryParams.status == null && this.queryParams.class == null) {
-            this._resetZoom();
-        }
-        this._getLookupOptions("", "")
-        console.log("queryParams (remove)", this.queryParams)
     }
 }

--- a/report-ng/app/src/components/threads/threads.ts
+++ b/report-ng/app/src/components/threads/threads.ts
@@ -322,8 +322,11 @@ export class Threads extends AbstractViewModel {
                 const itemColor = style.get(context.resultStatus);
                 const duration = context.contextValues.endTime - context.contextValues.startTime;
                 const classId = executionStatistics.classStatistics.find(classStat => {
-                    return classStat.classContext.contextValues.id == context.classContextId;
-                }).classIdentifier;
+                    const classContextIds = classStat.methodContexts
+                        .map(con => con.classContextId)
+                        .filter((value, index, self) => self.indexOf(value) === index);
+                    return classContextIds.includes(context.classContextId);
+                }).classIdentifier
 
                 data.push({
                     name: context.contextValues.name,

--- a/report-ng/app/src/components/threads/threads.ts
+++ b/report-ng/app/src/components/threads/threads.ts
@@ -87,6 +87,7 @@ export class Threads extends AbstractViewModel {
     attached() {
         this._statisticsGenerator.getExecutionStatistics().then(executionStatistics => {
             this._executionStatistics = executionStatistics;
+            this._executionStatistics.classStatistics.sort((a, b) => this._classNameValueConverter.toView(a.classIdentifier, 1).localeCompare(this._classNameValueConverter.toView(b.classIdentifier, 1)))
             this._availableStatuses = [];
             this._availableStatuses = executionStatistics.availableStatuses;
             this._initDateFormatter();

--- a/report-ng/app/src/components/threads/threads.ts
+++ b/report-ng/app/src/components/threads/threads.ts
@@ -100,25 +100,24 @@ export class Threads extends AbstractViewModel {
         super.activate(params, routeConfig, navInstruction);
         this._router = navInstruction.router;
 
+        const self = this
         if (this.queryParams.status || params.status) {
-            (async () => {
-                this._selectedStatus = this._statusConverter.getStatusForClass(params.status);
-                await new Promise(f => setTimeout(f, 200));
-                this._zoomInOnFilter(this._statusConverter.getStatusForClass(params.status), 7);
-                this.statusSelect.value = this._statusConverter.normalizeStatus(this._statusConverter.getStatusForClass(this.queryParams.status)).toString();       // necessary to keep selection after refreshing the page
-            })();
-        } else {
+            window.setTimeout(() => {
+                self._selectedStatus = self._statusConverter.getStatusForClass(params.status);
+                self._zoomInOnFilter(self._statusConverter.getStatusForClass(params.status), 7)
+                self.statusSelect.value = self._statusConverter.normalizeStatus(self._statusConverter.getStatusForClass(self.queryParams.status)).toString();       // necessary to keep selection after refreshing the page
+            }, 200)
+        }  else {
             this._selectedStatus = null;
         }
 
         if (this.queryParams.class || params.class) {
-            (async () => {
-                this._selectedClass = params.class;
-                await new Promise(f => setTimeout(f, 200));
-                this._zoomInOnFilter(params.class, 8);
-                this.classSelect.value = this._executionStatistics.classStatistics.find(classStat => classStat.classIdentifier == this.queryParams.class).classIdentifier;      // necessary to keep selection after refreshing the page
-            })();
-        } else {
+            window.setTimeout(() => {
+                self._selectedClass = params.class;
+                self._zoomInOnFilter(params.class, 8);
+                self.classSelect.value = self._executionStatistics.classStatistics.find(classStat => classStat.classIdentifier == self.queryParams.class).classIdentifier;      // necessary to keep selection after refreshing the page
+            }, 200)
+        }  else {
             this._selectedClass = null;
         }
     };

--- a/report-ng/app/src/components/threads/threads.ts
+++ b/report-ng/app/src/components/threads/threads.ts
@@ -39,6 +39,7 @@ import {
 import {ResultStatusType} from "../../services/report-model/framework_pb";
 import {ClassName, ClassNameValueConverter} from "../../value-converters/class-name-value-converter";
 import MethodContext = data.MethodContext;
+import {MdcSelect} from "@aurelia-mdc-web/select";
 
 interface MethodInfo {
     id: string;
@@ -53,6 +54,8 @@ export class Threads extends AbstractViewModel {
     private _availableStatuses: data.ResultStatusType[] | number[];
     private _selectedStatus: data.ResultStatusType;
     private _selectedClass: string;
+    private statusSelect: MdcSelect;
+    private classSelect: MdcSelect;
     private _executionStatistics: ExecutionStatistics;
     private _initialChartLoading = true;
     private _filterActive = false;          // To prevent unnecessary method calls
@@ -102,6 +105,7 @@ export class Threads extends AbstractViewModel {
                 this._selectedStatus = this._statusConverter.getStatusForClass(params.status);
                 await new Promise(f => setTimeout(f, 200));
                 this._zoomInOnFilter(this._statusConverter.getStatusForClass(params.status), 7);
+                this.statusSelect.value = this._statusConverter.normalizeStatus(this._statusConverter.getStatusForClass(this.queryParams.status)).toString();       // necessary to keep selection after refreshing the page
             })();
         } else {
             this._selectedStatus = null;
@@ -112,6 +116,7 @@ export class Threads extends AbstractViewModel {
                 this._selectedClass = params.class;
                 await new Promise(f => setTimeout(f, 200));
                 this._zoomInOnFilter(params.class, 8);
+                this.classSelect.value = this._executionStatistics.classStatistics.find(classStat => classStat.classIdentifier == this.queryParams.class).classIdentifier;      // necessary to keep selection after refreshing the page
             })();
         } else {
             this._selectedClass = null;

--- a/report-ng/app/src/styles/mdc.scss
+++ b/report-ng/app/src/styles/mdc.scss
@@ -25,8 +25,8 @@
   $on-primary: #ffffff,
   $on-secondary: #ffffff,
 );
-//@use '@material/button/mdc-button';
-//@use '@material/button';
+@use '@material/button/mdc-button';
+@use '@material/button';
 @use '@material/card/mdc-card';
 @use '@material/card';
 @use '@material/checkbox';


### PR DESCRIPTION
# Description

* added class filter for threads view
* filters can not be active at the same time => to prevent this and show user that he cannot use them at the same time, filters will be disabled
  * note: to achieve this, we need extra variables `_selectedClass` and `_selectedStatus`; otherwise after refreshing the page while we have an active filter, the other both filter fields will not be disabled anymore
  * note: when we have one of the select filters active (class or status) the selection was removed out of the select box although the filter remained active. This caused that you were neither able to deactivate the filter nor activate another filter since they were disabled 
  => to solve this i added "ref" to the mdc-selects which modify `statusSelect` and `classSelect` 
  => these will put the selected filter option actively in the select field again when the filter is reactivated after a page refresh 
  (feel free to ask me if anything is unclear here, also see https://aurelia-ui-toolkits.github.io/aurelia-mdc-web/#/select/examples first example - 'Select Banana' Button)
* summarized zoomInOnMethods(), zoomInOnMethodsWithStatus() to one function _zoomInOnFilter() to be able to reuse it for method, status and class filter
* added class information to the tooltip 

_note for screenshots: the zoom still works, i just cut off the lower part of the threads view in these screenshots_
![image](https://github.com/telekom/testerra/assets/138661340/f6d65329-8100-40e3-bac0-8d6e7ab60f6e)

![image](https://github.com/telekom/testerra/assets/138661340/4f3bb767-aa5a-4af8-99de-f70c8252f3f6)


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
