### PR TITLE
Fix/local WebDriver proxy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ ext {
 
     seleniumVersion = '4.23.0'
     // Must be the same like in Selenium 4
-    guavaVersion = "33.0.0-jre"
+    guavaVersion = "33.2.1-jre"
 
     moduleVersion = '2-SNAPSHOT'
     if (System.properties.containsKey('ttVersion')) {

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ ext {
     core = project(':core')
     report = project(':report-ng')
 
-    seleniumVersion = '4.21.0'
+    seleniumVersion = '4.21.0' // TODO: Update to Selenium 4.23.0 to fix the local webdriver proxy issue: https://github.com/SeleniumHQ/selenium/issues/14162
     // Must be the same like in Selenium 4
     guavaVersion = "33.0.0-jre"
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ ext {
     core = project(':core')
     report = project(':report-ng')
 
-    seleniumVersion = '4.21.0' // TODO: Update to Selenium 4.23.0 to fix the local webdriver proxy issue: https://github.com/SeleniumHQ/selenium/issues/14162
+    seleniumVersion = '4.23.0'
     // Must be the same like in Selenium 4
     guavaVersion = "33.0.0-jre"
 

--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/utils/ProxyUtils.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/utils/ProxyUtils.java
@@ -59,14 +59,14 @@ public class ProxyUtils implements PropertyManagerProvider {
         String proxyString = "";
 
         final String proxyHost = PROPERTY_MANAGER.getProperty(proxyType + ".proxyHost");
-        if (proxyHost != null) {
+        if (StringUtils.isNotBlank(proxyHost)) {
             proxyString += proxyHost;
         } else {
             return null;
         }
 
         final String proxyPort = PROPERTY_MANAGER.getProperty(proxyType + ".proxyPort");
-        if (proxyPort != null) {
+        if (StringUtils.isNotBlank(proxyHost)) {
             proxyString += ":" + proxyPort;
         }
 

--- a/docs/src/docs/selenium4/selenium4-cdp.adoc
+++ b/docs/src/docs/selenium4/selenium4-cdp.adoc
@@ -170,7 +170,7 @@ public class ChromeDevToolsTests extends TesterraTest implements
 .'Broken' page resources
 [source, java]
 ----
-import org.openqa.selenium.devtools.v125.log.model.LogEntry;
+import org.openqa.selenium.devtools.v127.log.model.LogEntry;
 ...
 
 public class ChromeDevToolsTests extends TesterraTest implements
@@ -211,9 +211,9 @@ public class ChromeDevToolsTests extends TesterraTest implements
 
 [source, java]
 ----
-import org.openqa.selenium.devtools.v125.network.Network;
-import org.openqa.selenium.devtools.v125.network.model.RequestWillBeSent;
-import org.openqa.selenium.devtools.v125.network.model.ResponseReceived;
+import org.openqa.selenium.devtools.v127.network.Network;
+import org.openqa.selenium.devtools.v127.network.model.RequestWillBeSent;
+import org.openqa.selenium.devtools.v127.network.model.ResponseReceived;
 ...
 
 public class ChromeDevToolsTests extends TesterraTest implements

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/testing/SeleniumChromeDevTools.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/testing/SeleniumChromeDevTools.java
@@ -28,10 +28,9 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.devtools.DevTools;
 import org.openqa.selenium.devtools.HasDevTools;
-
-import org.openqa.selenium.devtools.v125.emulation.Emulation;
-import org.openqa.selenium.devtools.v125.network.Network;
-import org.openqa.selenium.devtools.v125.network.model.Headers;
+import org.openqa.selenium.devtools.v127.emulation.Emulation;
+import org.openqa.selenium.devtools.v127.network.Network;
+import org.openqa.selenium.devtools.v127.network.model.Headers;
 import org.openqa.selenium.remote.Augmenter;
 import org.openqa.selenium.remote.RemoteWebDriver;
 

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/WebDriverProxyUtils.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/WebDriverProxyUtils.java
@@ -57,7 +57,7 @@ public class WebDriverProxyUtils {
     }
 
     /**
-     * @return Proxy based on an URL including socks proxy settings
+     * @return Proxy based on a URL including socks proxy settings
      */
     public Proxy createSocksProxyFromUrl(URL url) {
         Proxy proxy = createHttpProxyFromUrl(url);
@@ -76,7 +76,7 @@ public class WebDriverProxyUtils {
     }
 
     /**
-     * @return Proxy based on an URL without socks proxy settings
+     * @return Proxy based on a URL without socks proxy settings
      */
     public Proxy createHttpProxyFromUrl(URL url) {
         String proxyString = toProxyString(url);
@@ -102,6 +102,11 @@ public class WebDriverProxyUtils {
         URL systemProxyUrl = ProxyUtils.getSystemHttpsProxyUrl();
         if (systemProxyUrl == null) {
             systemProxyUrl = ProxyUtils.getSystemHttpProxyUrl();
+        }
+        if (systemProxyUrl == null) {
+            Proxy proxy = new Proxy();
+            proxy.setProxyType(Proxy.ProxyType.AUTODETECT);
+            return proxy;
         }
         Proxy proxy = createHttpProxyFromUrl(systemProxyUrl);
         proxy.setNoProxy(PropertyManager.getProperty("https.nonProxyHosts"));


### PR DESCRIPTION
# Description

- The usage of a local WebDriver and a proxy with no set properties caused an Error: `a value is required for '--proxy <PROXY>' but none was supplied` so that the browser session could not be started.
- The corresponding Selenium-Issue (https://github.com/SeleniumHQ/selenium/issues/14162) was fixed for version `4.23.0`


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
