### PR TITLE
remove deprecated methode from AbstractPage

### DIFF
--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/internal/AbstractPage.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/internal/AbstractPage.java
@@ -56,7 +56,7 @@ import org.openqa.selenium.WebDriver;
  * Livecycle methods for {@link #checkUiElements(CheckRule)}:
  *      {@link #checkPagePreparation()}
  *      {@link #addCustomFieldActions}
- *      {@link #assertPageIsNotShown()} or {@link #assertPageIsNotShown()}
+ *
  *      {@link #checkPageErrorState(Throwable)}
  * @see {https://martinfowler.com/bliki/PageObject.html}
  * @author Peter Lehmann
@@ -95,21 +95,6 @@ public abstract class AbstractPage<SELF> implements
     protected UiElement createEmpty(Locator locator) {
         return new EmptyUiElement(this, locator);
     }
-
-    /**
-     * Calls the assertPageIsShown method.
-     */
-    private void checkAdditional(CheckRule checkRule) {
-        switch (checkRule) {
-            case IS_NOT_PRESENT:
-            case IS_NOT_DISPLAYED:
-                assertPageIsNotShown();
-                break;
-            default:
-                assertPageIsShown();
-        }
-    }
-
     /**
      * Package private accessible by {@link PageFactory}
      */
@@ -148,7 +133,6 @@ public abstract class AbstractPage<SELF> implements
         checkPagePreparation();
         try {
             checkAnnotatedFields(checkRule);
-            checkAdditional(checkRule);
         } catch (Throwable throwable) {
             // call page error state logic
             checkPageErrorState(throwable);
@@ -254,13 +238,6 @@ public abstract class AbstractPage<SELF> implements
     /**
      * Empty method to be overriden. Can perform some (additional) checks on page objects.
      */
-    @Deprecated
-    public void assertPageIsShown() {
-    }
-
-    @Deprecated
-    public void assertPageIsNotShown() {
-    }
 
     @Override
     abstract public WebDriver getWebDriver();


### PR DESCRIPTION
# Description

 remove deprecated method (assertPageIsShown/-NotShown) from AbstractPage

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
