### PR TITLE
Changed UiElement.scrollIntoView to 'window.scroll()' solution

### DIFF
--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/utils/JSUtils.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/utils/JSUtils.java
@@ -478,20 +478,26 @@ public final class JSUtils implements Loggable {
      * Also working with elements in frames/iframes
      */
     public void scrollToCenter(UiElement uiElement, Point offset) {
+        // Get location via JSUtils method to support frames/iframes
+        Point elementLocationInParent = new JSUtils().getElementLocationInParent(uiElement);
+
+        final String js = String.format(
+                "const elementRect = arguments[0].getBoundingClientRect();" +
+                        "const scrollX = %d + (elementRect.width /2) - (window.innerWidth / 2);" +
+                        "const scrollY = %d + (elementRect.height / 2) - (window.innerHeight / 2);" +
+                        "window.scrollBy(scrollX + %s, scrollY + %s)",
+                elementLocationInParent.getX(),
+                elementLocationInParent.getY(),
+                offset.getX(),
+                offset.getY());
+
         uiElement.findWebElement(webElement -> {
             JSUtils.executeScript(
                     uiElement.getWebDriver(),
-                    "arguments[0].scrollIntoView({ block: 'center', inline: 'center' });",
+                    js,
                     webElement
             );
         });
-
-        JSUtils.executeScript(
-                uiElement.getWebDriver(),
-                "window.scrollBy(arguments[0], arguments[1]);",
-                offset != null ? offset.getX() : 0,
-                offset != null ? offset.getY() : 0
-        );
 
     }
 


### PR DESCRIPTION
# Description

Changed again the behaviour of `element.scrollIntoView`. Now the JS `window.sroll()` method is used instead of `arguments[0].scrollIntoView`.

The scrolling is much more stable and it is also allowed to scroll up.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
