### PR TITLE
Added helper method to use CDP device emulation

### DIFF
--- a/docs/src/docs/selenium4/selenium4-cdp.adoc
+++ b/docs/src/docs/selenium4/selenium4-cdp.adoc
@@ -259,4 +259,41 @@ public class ChromeDevToolsTests extends TesterraTest implements
 
 ----
 
+== Set device emulation
 
+There is a simple implementation to emulate mobile devices.
+
+[source, java]
+----
+
+public class ChromeDevToolsTests extends TesterraTest implements
+        ChromeDevToolsProvider,
+        WebDriverManagerProvider {
+
+    @Test
+    public void test_CDP_GeoLocation() {
+        WebDriver webDriver = WEB_DRIVER_MANAGER.getWebDriver();
+
+        CHROME_DEV_TOOLS.setDevice(
+                webDriver,
+                new Dimension(400, 900),    // resolution
+                100,                        // Scale factor
+                true);                      // it's a mobile device
+
+        webDriver.get("...");
+    }
+
+}
+
+----
+
+If you need some more impact on device settings, you can use the origin method
+
+[source, java]
+----
+WebDriver webDriver = WEB_DRIVER_MANAGER.getWebDriver();
+DevTools devTools = CHROME_DEV_TOOLS.getRawDevTools(webDriver);
+devTools.send(Emulation.setDeviceMetricsOverride(...);
+----
+
+See here for more details: https://chromedevtools.github.io/devtools-protocol/tot/Emulation/#method-setDeviceMetricsOverride

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/internal/ResponsiveClassFinder.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/internal/ResponsiveClassFinder.java
@@ -214,7 +214,9 @@ final public class ResponsiveClassFinder {
             // mehrfaches auslesen verhindern, nur auslesen wenn nötig
             return viewportWidth;
         }
-        Object o = JSUtils.executeScript(driver, "return window.innerWidth");
+        // In case of using Chrome CDP device emulation
+        // https://developer.chrome.com/blog/visual-viewport-api
+        Object o = JSUtils.executeScript(driver, "return window.visualViewport.width");
         if (o instanceof Long) {
             int viewportWidthNew = (int) (long) (Long) o;
             LOGGER.debug(String.format("Browser viewport width is %dpx", viewportWidthNew));

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/testing/SeleniumChromeDevTools.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/testing/SeleniumChromeDevTools.java
@@ -23,6 +23,7 @@ package eu.tsystems.mms.tic.testframework.testing;
 import eu.tsystems.mms.tic.testframework.logging.Loggable;
 import eu.tsystems.mms.tic.testframework.webdrivermanager.ChromeDevTools;
 import org.openqa.selenium.Credentials;
+import org.openqa.selenium.Dimension;
 import org.openqa.selenium.UsernameAndPassword;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
@@ -88,6 +89,32 @@ public class SeleniumChromeDevTools implements ChromeDevTools, Loggable {
                 Optional.of(longitude),
                 Optional.of(accuracy)));
         log().info("Changed geolocation information to lat={}, long={}", latitude, longitude);
+    }
+
+    @Override
+    public void setDevice(WebDriver webDriver, Dimension dimension, int scaleFactor, boolean mobile) {
+        if (!isSupported(webDriver)) {
+            throw new RuntimeException("The current browser does not support DevTools");
+        }
+        DevTools devTools = this.getRawDevTools(webDriver);
+        devTools.send(Emulation.setDeviceMetricsOverride(
+                        dimension.getWidth(),
+                        dimension.getHeight(),
+                        100,
+                        true,
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty()
+                )
+        );
+        log().info("Changed device metrics to {}x{} with scale={}", dimension.getWidth(), dimension.getHeight(), scaleFactor);
     }
 
     @Override

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/ChromeDevTools.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/ChromeDevTools.java
@@ -23,6 +23,7 @@ package eu.tsystems.mms.tic.testframework.webdrivermanager;
 import eu.tsystems.mms.tic.testframework.constants.Browsers;
 import eu.tsystems.mms.tic.testframework.testing.WebDriverManagerProvider;
 import org.openqa.selenium.Credentials;
+import org.openqa.selenium.Dimension;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.devtools.DevTools;
 
@@ -39,6 +40,8 @@ public interface ChromeDevTools extends WebDriverManagerProvider {
     DevTools getRawDevTools(WebDriver webDriver);
 
     void setGeoLocation(WebDriver webDriver, double latitude, double longitude, int accuracy);
+
+    void setDevice(WebDriver webDriver, Dimension dimension, int scaleFactor, boolean mobile);
 
     void setBasicAuthentication(WebDriver webDriver, Supplier<Credentials> credentials);
 

--- a/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/playground/ChromeDevToolsTests.java
+++ b/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/playground/ChromeDevToolsTests.java
@@ -27,6 +27,7 @@ import eu.tsystems.mms.tic.testframework.testing.ChromeDevToolsProvider;
 import eu.tsystems.mms.tic.testframework.utils.TimerUtils;
 import eu.tsystems.mms.tic.testframework.webdrivermanager.DesktopWebDriverRequest;
 import org.openqa.selenium.By;
+import org.openqa.selenium.Dimension;
 import org.openqa.selenium.HasAuthentication;
 import org.openqa.selenium.JavascriptException;
 import org.openqa.selenium.UsernameAndPassword;
@@ -336,6 +337,15 @@ public class ChromeDevToolsTests extends AbstractWebDriverTest implements Chrome
         for (ResponseReceived response : responseReceivedList) {
             log().info("Response: {} - [{}] {}", response.getRequestId().toString(), response.getResponse().getStatus(), response.getResponse().getStatusText());
         }
+    }
+
+    @Test
+    public void testT14_MobileDeviceEmulation() {
+        WebDriver webDriver = WEB_DRIVER_MANAGER.getWebDriver();
+        CHROME_DEV_TOOLS.setDevice(webDriver, new Dimension(400, 900), 100, true);
+
+        webDriver.get("https://the-internet.herokuapp.com/broken_images");
+
     }
 
 }


### PR DESCRIPTION
# Description

For testing responsive design the Chrome device emulation mode could be very helpful to simulate mobile devices.

This PR adds a method to easy use the emulation mode.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
