### PR TITLE
added html escape to log messages

### DIFF
--- a/report-ng/app/package-lock.json
+++ b/report-ng/app/package-lock.json
@@ -44,7 +44,7 @@
                 "highlight.js": "^11.8.0",
                 "moment": "^2.29.4",
                 "moment-duration-format": "^2.3.2",
-                "t-systems-aurelia-components": "^1.1.1",
+                "t-systems-aurelia-components": "^1.1.8",
                 "vis-network": "^7.4.2"
             },
             "devDependencies": {
@@ -7047,9 +7047,9 @@
             "dev": true
         },
         "node_modules/t-systems-aurelia-components": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/t-systems-aurelia-components/-/t-systems-aurelia-components-1.1.1.tgz",
-            "integrity": "sha512-/Meblp9GgKjiYPR8PJmyAYozm/2UJzhfMmQMK8LipRsHonFb5xXk7OOri4PJlSjZk2Bisp83IhNZb3AbTfCObA==",
+            "version": "1.1.8",
+            "resolved": "https://registry.npmjs.org/t-systems-aurelia-components/-/t-systems-aurelia-components-1.1.8.tgz",
+            "integrity": "sha512-+im+QFpSCOQSIttG0AWBunQAAdkEwRUoTJThz+B61iRcSHar1Z9bi66W6n4gK/y5h5GRoJ1Ca6fVxQpSTEhoeA==",
             "peerDependencies": {
                 "apexcharts": "^3.35.0",
                 "aurelia-templating": "^1.11.1",
@@ -13955,9 +13955,9 @@
             "dev": true
         },
         "t-systems-aurelia-components": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/t-systems-aurelia-components/-/t-systems-aurelia-components-1.1.1.tgz",
-            "integrity": "sha512-/Meblp9GgKjiYPR8PJmyAYozm/2UJzhfMmQMK8LipRsHonFb5xXk7OOri4PJlSjZk2Bisp83IhNZb3AbTfCObA==",
+            "version": "1.1.8",
+            "resolved": "https://registry.npmjs.org/t-systems-aurelia-components/-/t-systems-aurelia-components-1.1.8.tgz",
+            "integrity": "sha512-+im+QFpSCOQSIttG0AWBunQAAdkEwRUoTJThz+B61iRcSHar1Z9bi66W6n4gK/y5h5GRoJ1Ca6fVxQpSTEhoeA==",
             "requires": {}
         },
         "tapable": {

--- a/report-ng/app/package-lock.json
+++ b/report-ng/app/package-lock.json
@@ -45,7 +45,6 @@
                 "moment": "^2.29.4",
                 "moment-duration-format": "^2.3.2",
                 "t-systems-aurelia-components": "^1.1.1",
-                "ts-replace-all": "^1.0.0",
                 "vis-network": "^7.4.2"
             },
             "devDependencies": {
@@ -3003,16 +3002,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/core-js": {
-            "version": "3.13.1",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.13.1.tgz",
-            "integrity": "sha512-JqveUc4igkqwStL2RTRn/EPFGBOfEZHxJl/8ej1mXJR75V3go2mFF4bmUYkEIT1rveHKnkUlcJX/c+f1TyIovQ==",
-            "hasInstallScript": true,
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/core-js"
             }
         },
         "node_modules/core-util-is": {
@@ -7466,14 +7455,6 @@
                 "protobufjs": "^7.2.4"
             }
         },
-        "node_modules/ts-replace-all": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/ts-replace-all/-/ts-replace-all-1.0.0.tgz",
-            "integrity": "sha512-6uBtdkw3jHXkPtx/e9xB/5vcngMm17CyJYsS2YZeQ+9FdRnt6Ev5g931Sg2p+dxbtMGoCm13m3ax/obicTZIkQ==",
-            "dependencies": {
-                "core-js": "^3.4.1"
-            }
-        },
         "node_modules/tslib": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
@@ -10932,11 +10913,6 @@
                 }
             }
         },
-        "core-js": {
-            "version": "3.13.1",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.13.1.tgz",
-            "integrity": "sha512-JqveUc4igkqwStL2RTRn/EPFGBOfEZHxJl/8ej1mXJR75V3go2mFF4bmUYkEIT1rveHKnkUlcJX/c+f1TyIovQ=="
-        },
         "core-util-is": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -14243,14 +14219,6 @@
             "requires": {
                 "long": "^5.0.0",
                 "protobufjs": "^7.2.4"
-            }
-        },
-        "ts-replace-all": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/ts-replace-all/-/ts-replace-all-1.0.0.tgz",
-            "integrity": "sha512-6uBtdkw3jHXkPtx/e9xB/5vcngMm17CyJYsS2YZeQ+9FdRnt6Ev5g931Sg2p+dxbtMGoCm13m3ax/obicTZIkQ==",
-            "requires": {
-                "core-js": "^3.4.1"
             }
         },
         "tslib": {

--- a/report-ng/app/package.json
+++ b/report-ng/app/package.json
@@ -44,7 +44,7 @@
         "highlight.js": "^11.8.0",
         "moment": "^2.29.4",
         "moment-duration-format": "^2.3.2",
-        "t-systems-aurelia-components": "^1.1.1",
+        "t-systems-aurelia-components": "^1.1.8",
         "vis-network": "^7.4.2"
     },
     "devDependencies": {

--- a/report-ng/app/package.json
+++ b/report-ng/app/package.json
@@ -45,7 +45,6 @@
         "moment": "^2.29.4",
         "moment-duration-format": "^2.3.2",
         "t-systems-aurelia-components": "^1.1.1",
-        "ts-replace-all": "^1.0.0",
         "vis-network": "^7.4.2"
     },
     "devDependencies": {

--- a/report-ng/app/src/components/log-view/log-line.html
+++ b/report-ng/app/src/components/log-view/log-line.html
@@ -27,5 +27,5 @@
     [${logMessage.type | logLevel}]: <span title="${logger.package}.${logger.class}"
                                            innerhtml.bind="logger.class|highlightText:searchRegexp"></span><span> - </span><span
     innerhtml.bind="logMessage.message|htmlEscape|highlightText:searchRegexp"></span>
-    <div if.bind="logMessage.cause" innerhtml.bind="logMessage.cause|highlightText:searchRegexp"></div>
+    <div if.bind="logMessage.cause" innerhtml.bind="logMessage.cause|htmlEscape|highlightText:searchRegexp"></div>
 </template>

--- a/report-ng/app/src/components/log-view/log-line.html
+++ b/report-ng/app/src/components/log-view/log-line.html
@@ -26,6 +26,6 @@
     route-href="route: method; params.bind: {methodId: logMessage.methodContext.contextValues.id}">${logMessage.threadName}</a>]</span>
     [${logMessage.type | logLevel}]: <span title="${logger.package}.${logger.class}"
                                            innerhtml.bind="logger.class|highlightText:searchRegexp"></span><span> - </span><span
-    innerhtml.bind="logMessage.message|highlightText:searchRegexp"></span>
+    innerhtml.bind="logMessage.message|htmlEscape|highlightText:searchRegexp"></span>
     <div if.bind="logMessage.cause" innerhtml.bind="logMessage.cause|highlightText:searchRegexp"></div>
 </template>

--- a/report-ng/app/src/services/status-converter.ts
+++ b/report-ng/app/src/services/status-converter.ts
@@ -183,7 +183,7 @@ export class StatusConverter {
     }
 
     createRegexpFromSearchString(searchQuery:string) {
-        const specialCharacters = new RegExp("([.*+?^${}()|[\\]\\\\])", "g");
+        const specialCharacters = new RegExp('([.*+?^${}()|[\\]\\\\"])', "g");
         searchQuery = searchQuery.replace(specialCharacters, "\\$1");
         return new RegExp("(" + searchQuery + ")", "ig");
     }

--- a/report-ng/app/src/services/status-converter.ts
+++ b/report-ng/app/src/services/status-converter.ts
@@ -183,7 +183,7 @@ export class StatusConverter {
     }
 
     createRegexpFromSearchString(searchQuery:string) {
-        const specialCharacters = new RegExp("([\\[\\]\(\)\.])", "g");
+        const specialCharacters = new RegExp("([.*+?^${}()|[\\]\\\\])", "g");
         searchQuery = searchQuery.replace(specialCharacters, "\\$1");
         return new RegExp("(" + searchQuery + ")", "ig");
     }

--- a/report-ng/app/src/value-converters/html-escape-value-converter.ts
+++ b/report-ng/app/src/value-converters/html-escape-value-converter.ts
@@ -29,9 +29,8 @@ export class HtmlEscapeValueConverter {
             return value;
         }
         return value
-            .replaceAll('&','&amp;')
-            .replaceAll('<', '&lt')
-            .replaceAll('>', '&gt;')
+            .replaceAll(/<(?!br\b|\/?br>)/gi, '&lt')    // only escape < & > if they do not belong to <br> or </br>
+            .replaceAll(/(?<!<\/?br)>/gi, '&gt;')
             .replaceAll('"', '&quot;');
     }
 }

--- a/report-ng/app/src/value-converters/html-escape-value-converter.ts
+++ b/report-ng/app/src/value-converters/html-escape-value-converter.ts
@@ -20,7 +20,6 @@
  */
 
 import {autoinject} from "aurelia-framework";
-import 'ts-replace-all'
 
 @autoinject()
 export class HtmlEscapeValueConverter {

--- a/report-ng/app/src/value-converters/html-value-converter.ts
+++ b/report-ng/app/src/value-converters/html-value-converter.ts
@@ -20,7 +20,6 @@
  */
 
 import {autoinject} from "aurelia-framework";
-import 'ts-replace-all'
 
 @autoinject()
 export class HtmlValueConverter {

--- a/report-ng/app/tsconfig.json
+++ b/report-ng/app/tsconfig.json
@@ -11,7 +11,8 @@
         "allowSyntheticDefaultImports": true,
         "lib": [
             "es2019",
-            "dom"
+            "dom",
+            "ES2021.String"
         ],
         "moduleResolution": "node",
         "baseUrl": "src"


### PR DESCRIPTION
# Description

* html escape was accidently removed in this PR: https://github.com/telekom/testerra/pull/433/files#diff-82f6273a45570c3c56e82b8284b21f36b6f3d7486ffe4ee9d120c6ec9d314c95
* i reverted the change

* added ? and " as searchable strings 


* note: there is a known bug: if you search "&", escaped characters are converted and marked, see examples: 
![image](https://github.com/user-attachments/assets/04cc87e0-1568-4295-8ced-1e0c0f2825fc)
![image](https://github.com/user-attachments/assets/434789c1-fdcd-47ad-a7ee-e4edfa928c6c)


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
