### PR TITLE
Migrate DefaultReport from File to Path

### DIFF
--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/report/DefaultReport.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/report/DefaultReport.java
@@ -45,7 +45,7 @@ public class DefaultReport implements Report, Loggable {
 
     public DefaultReport() {
         FileUtils fileUtils = new FileUtils();
-        tempReportDirectory = fileUtils.createTempDir(baseDir);
+        tempReportDirectory = fileUtils.createTempDir("test-report");
         log().debug("Prepare report in " + tempReportDirectory.toAbsolutePath());
         currentReportDirectory = tempReportDirectory;
     }

--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/report/DefaultReport.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/report/DefaultReport.java
@@ -50,22 +50,16 @@ public class DefaultReport implements Report, Loggable {
         currentReportDirectory = tempReportDirectory;
     }
 
-    // TODO: Migrate to Path
-    private File addFile(File sourceFile, File directory, FileMode fileMode) {
+    private Path addFile(Path sourceFile, Path directory, FileMode fileMode) {
         try {
-            switch (fileMode) {
-                case COPY:
-                    FileUtils.copyFileToDirectory(sourceFile, directory, true);
-                    break;
-                default:
-                case MOVE:
-                    FileUtils.moveFileToDirectory(sourceFile, directory, true);
-                    break;
+            PathUtils.copyFileToDirectory(sourceFile, directory);
+            if (fileMode == FileMode.MOVE) {
+                Files.delete(sourceFile);
             }
         } catch (IOException e) {
             log().error("Could not add file", e);
         }
-        return new File(directory, sourceFile.getName());
+        return directory.resolve(sourceFile.getFileName());
     }
 
     public Path finalizeReport() {
@@ -95,11 +89,13 @@ public class DefaultReport implements Report, Loggable {
     private void addScreenshotFiles(Screenshot screenshot, FileMode fileMode) {
         Path screenshotsDirectory = getReportDirectory(SCREENSHOTS_FOLDER_NAME);
         if (screenshot.getScreenshotFile() != null) {
-            screenshot.setFile(addFile(screenshot.getScreenshotFile(), screenshotsDirectory.toFile(), fileMode));
+            Path path = addFile(screenshot.getScreenshotFile().toPath(), screenshotsDirectory, fileMode);
+            screenshot.setFile(path.toFile());
         }
 
         screenshot.getPageSourceFile().ifPresent(file -> {
-            screenshot.setPageSourceFile(addFile(file, screenshotsDirectory.toFile(), fileMode));
+            Path path = addFile(file.toPath(), screenshotsDirectory, fileMode);
+            screenshot.setPageSourceFile(path.toFile());
         });
     }
 
@@ -119,7 +115,8 @@ public class DefaultReport implements Report, Loggable {
     @Override
     public Report addVideo(Video video, FileMode fileMode) {
         Path videoDirectory = getReportDirectory(VIDEO_FOLDER_NAME);
-        video.setFile(addFile(video.getVideoFile(), videoDirectory.toFile(), fileMode));
+        Path path = addFile(video.getVideoFile().toPath(), videoDirectory, fileMode);
+        video.setFile(path.toFile());
         return this;
     }
 

--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/report/DefaultReport.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/report/DefaultReport.java
@@ -70,6 +70,7 @@ public class DefaultReport implements Report, Loggable {
 
             if (Files.exists(tempReportDirectory)) {
                 log().debug("Temporary directory is {}", tempReportDirectory);
+                Files.createDirectories(finalReportPath);
                 PathUtils.copyDirectory(tempReportDirectory, finalReportPath);
                 currentReportDirectory = finalReportPath;
                 log().info("Report written to " + finalReportPath.toAbsolutePath());

--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/report/Report.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/report/Report.java
@@ -24,8 +24,12 @@ package eu.tsystems.mms.tic.testframework.report;
 import eu.tsystems.mms.tic.testframework.common.IProperties;
 import eu.tsystems.mms.tic.testframework.report.model.context.Screenshot;
 import eu.tsystems.mms.tic.testframework.report.model.context.Video;
+import eu.tsystems.mms.tic.testframework.utils.FileUtils;
+
 import java.io.File;
 import java.lang.annotation.Annotation;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Optional;
 
 public interface Report {
@@ -83,32 +87,35 @@ public interface Report {
 
     Report addVideo(Video video, FileMode fileMode);
     Video provideVideo(File file, FileMode fileMode);
-    File finalizeReport();
+    Path finalizeReport();
 
-    File getReportDirectory();
+    Path getReportDirectory();
 
     /**
      * @param childName Child directory or file name
      * @return Final report sub directory defined by the user
      */
-    default File getReportDirectory(String childName) {
-        File dir = new File(getReportDirectory(), childName);
-        if (!dir.exists()) {
-            dir.mkdirs();
+    default Path getReportDirectory(String childName) {
+        Path path = getReportDirectory().resolve(childName);
+        if (!Files.exists(path)) {
+            new FileUtils().createDirectoriesSafely(path);
         }
-        return dir;
+        return path;
     }
-    default File getReportFile(String filePath) {
-        File file = new File(getReportDirectory(), filePath);
-        File dir = file.getParentFile();
-        if (!dir.exists()) {
-            dir.mkdirs();
+
+    default Path getReportFile(String filePath) {
+        Path path = getReportDirectory().resolve(Path.of(filePath));
+        Path dir = path.getParent();
+        if (!Files.exists(dir)) {
+            new FileUtils().createDirectoriesSafely(dir);
         }
-        return file;
+        return path;
     }
-    File getFinalReportDirectory();
-    default File getFinalReportDirectory(String childName) {
-        return new File(getFinalReportDirectory(), childName);
+
+    Path getFinalReportDirectory();
+
+    default Path getFinalReportDirectory(String childName) {
+        return getFinalReportDirectory().resolve(Path.of(childName));
     }
 
     /**

--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/utils/FileUtils.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/utils/FileUtils.java
@@ -26,6 +26,7 @@ import eu.tsystems.mms.tic.testframework.exceptions.FileNotFoundException;
 import eu.tsystems.mms.tic.testframework.exceptions.SystemException;
 import eu.tsystems.mms.tic.testframework.logging.Loggable;
 import org.apache.commons.io.FilenameUtils;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -37,6 +38,9 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -261,9 +265,26 @@ public final class FileUtils extends org.apache.commons.io.FileUtils implements 
                 (extension.length() > 0 ? "." + extension : ""));
     }
 
-    public File createTempDir(String dirName) {
-        File dir = new File(System.getProperty("java.io.tmpdir") + "/" + dirName + "-" + UUID.randomUUID());
-        dir.mkdirs();
-        return dir;
+    public Path createTempDir(String dirName) {
+        try {
+//            Path dir = Path.of(System.getProperty("java.io.tmpdir"), dirName + "-" + UUID.randomUUID());
+
+            return Files.createTempDirectory(dirName + "_");
+        } catch (IOException e) {
+            throw new SystemException("Cannot create temporary folder " + dirName, e);
+        }
+    }
+
+    public boolean createDirectoriesSafely(Path path) {
+        try {
+            Files.createDirectories(path);
+            return true;
+        } catch (FileAlreadyExistsException e) {
+            log().error("Folder already exists: {}", path.toAbsolutePath());
+            return false;
+        } catch (IOException e) {
+            log().error("Cannot create folder {}: {}", path.toAbsolutePath(), e.getMessage());
+            return false;
+        }
     }
 }

--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/utils/PdfUtils.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/utils/PdfUtils.java
@@ -36,6 +36,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -280,9 +281,8 @@ public final class PdfUtils {
         }
 
         FileUtils utils = new FileUtils();
-        File tempDir = utils.createTempDir(fileName);
-
-        return tempDir.getAbsolutePath() + File.separator + fileName;
+        Path tempDir = utils.createTempDir(fileName);
+        return tempDir.resolve(fileName).toAbsolutePath().toString();
     }
 
     private static void closeDocument(PDDocument pdDoc) {

--- a/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/pagefactory/PageFactoryTest.java
+++ b/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/pagefactory/PageFactoryTest.java
@@ -36,7 +36,9 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 /**
  * Tests the responsive page factory for correct instantiated classes.
@@ -44,23 +46,23 @@ import java.io.File;
 public class PageFactoryTest extends AbstractTestSitesTest implements PageFactoryProvider, PropertyManagerProvider {
 
     @Test
-    public void testT08_CheckPage_ScreenshotOnLoad() {
+    public void testT08_CheckPage_ScreenshotOnLoad() throws IOException {
 
-        final File reportScreenshotDirectory = Testerra.getInjector().getInstance(Report.class).getReportDirectory(Report.SCREENSHOTS_FOLDER_NAME);
+        final Path reportScreenshotDirectory = Testerra.getInjector().getInstance(Report.class).getReportDirectory(Report.SCREENSHOTS_FOLDER_NAME);
         Assert.assertNotNull(reportScreenshotDirectory);
 
         final WebDriver driver = getWebDriver();
 
-        final int fileCountBeforeAction = getNumFiles(reportScreenshotDirectory);
+        final long fileCountBeforeAction = getNumFiles(reportScreenshotDirectory);
         PROPERTY_MANAGER.setTestLocalProperty(Testerra.Properties.SCREENSHOT_ON_PAGELOAD, false);
         PAGE_FACTORY.createPage(PageWithExistingElement.class, driver);
 
-        final int fileCountAfterCheckPageWithoutScreenshot = getNumFiles(reportScreenshotDirectory);
+        final long fileCountAfterCheckPageWithoutScreenshot = getNumFiles(reportScreenshotDirectory);
         Assert.assertEquals(fileCountBeforeAction, fileCountAfterCheckPageWithoutScreenshot, "Record Screenshot count not altered.");
 
         PROPERTY_MANAGER.setTestLocalProperty(Testerra.Properties.SCREENSHOT_ON_PAGELOAD, true);
         PAGE_FACTORY.createPage(PageWithExistingElement.class, driver);
-        final int fileCountAfterCheckPageWithScreenshot = getNumFiles(reportScreenshotDirectory);
+        final long fileCountAfterCheckPageWithScreenshot = getNumFiles(reportScreenshotDirectory);
 
         Assert.assertNotEquals(fileCountAfterCheckPageWithoutScreenshot, fileCountAfterCheckPageWithScreenshot, "Record Screenshot count altered.");
     }
@@ -112,13 +114,8 @@ public class PageFactoryTest extends AbstractTestSitesTest implements PageFactor
         }
     }
 
-    private int getNumFiles(File directory) {
-        File[] files = directory.listFiles();
-        if (files == null) {
-            return 0;
-        } else {
-            return files.length;
-        }
+    private long getNumFiles(Path directory) throws IOException {
+        return Files.list(directory).count();
     }
 
 }

--- a/report-model/src/main/java/eu/tsystems/mms/tic/testframework/listeners/GenerateJUnitXML2ReportListener.java
+++ b/report-model/src/main/java/eu/tsystems/mms/tic/testframework/listeners/GenerateJUnitXML2ReportListener.java
@@ -198,7 +198,7 @@ public class GenerateJUnitXML2ReportListener implements
 
         document.pop();
 
-        Utils.writeUtf8File(report.getReportDirectory(Report.XML_FOLDER_NAME).getAbsolutePath(), XML_RESULT_FILENAME, document.toXML());
+        Utils.writeUtf8File(report.getReportDirectory(Report.XML_FOLDER_NAME).toAbsolutePath().toString(), XML_RESULT_FILENAME, document.toXML());
     }
 
     static String formattedTime() {

--- a/report-ng/src/main/java/eu/tsystems/mms/tic/testframework/hook/ReportNgHook.java
+++ b/report-ng/src/main/java/eu/tsystems/mms/tic/testframework/hook/ReportNgHook.java
@@ -30,6 +30,8 @@ import eu.tsystems.mms.tic.testframework.listeners.CopyReportAppListener;
 import eu.tsystems.mms.tic.testframework.listeners.GenerateReportNgModelListener;
 import eu.tsystems.mms.tic.testframework.report.Report;
 
+import java.nio.file.Path;
+
 public class ReportNgHook extends AbstractModule implements ModuleHook {
 
     @Override
@@ -38,8 +40,8 @@ public class ReportNgHook extends AbstractModule implements ModuleHook {
 
         Report report = Testerra.getInjector().getInstance(Report.class);
 
-        eventBus.register(new CopyReportAppListener(report.getReportDirectory()));
-        eventBus.register(new GenerateReportNgModelListener(report.getReportDirectory("report-ng/model")));
+        eventBus.register(new CopyReportAppListener(report.getReportDirectory().toFile()));
+        eventBus.register(new GenerateReportNgModelListener(report.getReportDirectory().resolve(Path.of("report-ng/model")).toFile()));
     }
 
     @Override

--- a/report-ng/src/main/java/eu/tsystems/mms/tic/testframework/hook/ReportNgHook.java
+++ b/report-ng/src/main/java/eu/tsystems/mms/tic/testframework/hook/ReportNgHook.java
@@ -40,7 +40,7 @@ public class ReportNgHook extends AbstractModule implements ModuleHook {
 
         Report report = Testerra.getInjector().getInstance(Report.class);
 
-        eventBus.register(new CopyReportAppListener(report.getReportDirectory().toFile()));
+        eventBus.register(new CopyReportAppListener(report.getReportDirectory()));
         eventBus.register(new GenerateReportNgModelListener(report.getReportDirectory().resolve(Path.of("report-ng/model")).toFile()));
     }
 

--- a/report-ng/src/main/java/eu/tsystems/mms/tic/testframework/listeners/CopyReportAppListener.java
+++ b/report-ng/src/main/java/eu/tsystems/mms/tic/testframework/listeners/CopyReportAppListener.java
@@ -46,6 +46,7 @@ public class CopyReportAppListener implements FinalizeExecutionEvent.Listener, L
 
     private File targetDir;
 
+    // TODO: Migrate to Path
     public CopyReportAppListener(File targetDir) {
         this.targetDir = targetDir;
     }


### PR DESCRIPTION
# Description

Since using the updated libs of `commons-io:commons-io` (#426) there is an issue in generating the final report directory in a special case:
Running a test of a Gradle module with `gradle submodule:test` the `user.dir` is the project root but `java.io.File` creates files under `<root>/submodule`. Current `FileUtils` class is using `java.nio.Path` which tries to operate only the real `user.dir`. 
Under Windows the report can be generated, but an old version cannot be deleted. Under Linux there is an exception at moving the report from temp to the final directory.

This PR migrates all file operations in `DefaultReport` to `java.nio.Path`. In case of running Gradle tests in submodules, the report will be placed in the real `user.dir`:
- `gradle submodule:test` --> `<project root>/test-report`
- `cd submodule && gradle test` --> `<project root>/submodule/test-report`

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
