### PR TITLE
Don't log a warning when the driver has already been closed

### DIFF
--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/WebDriverManagerUtils.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/webdrivermanager/WebDriverManagerUtils.java
@@ -24,6 +24,7 @@ package eu.tsystems.mms.tic.testframework.webdrivermanager;
 import eu.tsystems.mms.tic.testframework.common.Testerra;
 import eu.tsystems.mms.tic.testframework.useragents.BrowserInformation;
 import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.NoSuchSessionException;
 import org.openqa.selenium.WebDriver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -92,6 +93,9 @@ public final class WebDriverManagerUtils {
         }
         try {
             driver.quit();
+        } catch (final NoSuchSessionException e) {
+            // Closing all tabs likely also closed the whole session
+            LOGGER.debug("WebDriver has already quit.", e);
         } catch (final Throwable e) {
             LOGGER.warn("WebDriver could not be quit. May someone did before.", e);
         }

--- a/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/webdrivermanager/DesktopWebDriverFactoryTest.java
+++ b/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/webdrivermanager/DesktopWebDriverFactoryTest.java
@@ -29,7 +29,9 @@ import eu.tsystems.mms.tic.testframework.testing.TesterraTest;
 import eu.tsystems.mms.tic.testframework.testing.UiElementFinderFactoryProvider;
 import eu.tsystems.mms.tic.testframework.testing.WebDriverManagerProvider;
 import eu.tsystems.mms.tic.testframework.useragents.ChromeConfig;
+import eu.tsystems.mms.tic.testframework.useragents.FirefoxConfig;
 import eu.tsystems.mms.tic.testframework.webdrivermanager.DesktopWebDriverRequest;
+import eu.tsystems.mms.tic.testframework.webdrivermanager.IWebDriverManager;
 import eu.tsystems.mms.tic.testframework.webdrivermanager.WebDriverRequest;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Platform;
@@ -63,8 +65,10 @@ public class DesktopWebDriverFactoryTest extends TesterraTest implements WebDriv
 
         WebDriver driver = WEB_DRIVER_MANAGER.getWebDriver(request);
         String currentUrl = driver.getCurrentUrl();
-        // Empty baseUrl of Chrome
-        Assert.assertTrue(currentUrl.contains("data"), "Current URL is invalid - actual: " + currentUrl);
+        // Empty baseUrl
+        String browser = IWebDriverManager.Properties.BROWSER.asString();
+        String expectedURL = browser.equals(Browsers.firefox) ? "about:blank" : "data";
+        Assert.assertTrue(currentUrl.contains(expectedURL), "Current URL is invalid - actual: " + currentUrl);
     }
 
     @Test
@@ -111,6 +115,10 @@ public class DesktopWebDriverFactoryTest extends TesterraTest implements WebDriv
         customCaps.put("t05UserAgent", "yesyes");
         WEB_DRIVER_MANAGER.setUserAgentConfig(Browsers.chromeHeadless,
                 (ChromeConfig) options -> options.setCapability("custom:caps", customCaps));
+        WEB_DRIVER_MANAGER.setUserAgentConfig(Browsers.chrome,
+                (ChromeConfig) options -> options.setCapability("custom:caps", customCaps));
+        WEB_DRIVER_MANAGER.setUserAgentConfig(Browsers.firefox,
+                (FirefoxConfig) options -> options.setCapability("custom:caps", customCaps));
 
         WebDriver driver = WEB_DRIVER_MANAGER.getWebDriver();
 

--- a/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/webdrivermanager/WebDriverManagerTest.java
+++ b/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/webdrivermanager/WebDriverManagerTest.java
@@ -344,7 +344,7 @@ public class WebDriverManagerTest extends TesterraTest implements WebDriverManag
     public void testT14_UnwrapFromDecorated() {
         DesktopWebDriverRequest request = new DesktopWebDriverRequest();
         request.setBrowser(Browsers.chromeHeadless);
-        WebDriver driver = WEB_DRIVER_MANAGER.getWebDriver();
+        WebDriver driver = WEB_DRIVER_MANAGER.getWebDriver(request);
         Assert.assertTrue(driver instanceof Decorated);
 
         Optional<ChromeDriver> chromeDriver = WEB_DRIVER_MANAGER.unwrapWebDriver(driver, ChromeDriver.class);
@@ -355,7 +355,7 @@ public class WebDriverManagerTest extends TesterraTest implements WebDriverManag
     public void testT15_UnwrapWrongTypeFromDecorated() {
         DesktopWebDriverRequest request = new DesktopWebDriverRequest();
         request.setBrowser(Browsers.chromeHeadless);
-        WebDriver driver = WEB_DRIVER_MANAGER.getWebDriver();
+        WebDriver driver = WEB_DRIVER_MANAGER.getWebDriver(request);
         Assert.assertTrue(driver instanceof Decorated);
 
         Optional<FirefoxDriver> chromeDriver = WEB_DRIVER_MANAGER.unwrapWebDriver(driver, FirefoxDriver.class);


### PR DESCRIPTION
# Description

When using the Firefox webdriver and having set `tt.wdm.closewindows.aftertestmethods=true`, the WebDriverManagerUtil will log a warning containing a stacktrace after every execution of a test method. My assumption is, that when `quitWebDriverSession()` closes all tabs, the Firefox instance exits and the geckodriver will quit the session. Therefore, the call to `driver.quit()` coming afterwards will fail with a `NoSuchSessionException`. This should not be an issue, as the driver is expected to be quit anyways. But to prevent the logs from getting spammed with pointless stack traces, I added an additional catch-clause to only log this case on level DEBUG.
Also I had to make some changes to the tests to make them pass with `tt.browser=firefox` as well.

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
