### PR TITLE
Fix/improve element screenshot exception

### DIFF
--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/internal/core/AbstractWebDriverCore.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/internal/core/AbstractWebDriverCore.java
@@ -55,6 +55,7 @@ import org.openqa.selenium.interactions.Actions;
 import javax.imageio.ImageIO;
 import java.awt.Color;
 import java.awt.image.BufferedImage;
+import java.awt.image.RasterFormatException;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -737,11 +738,13 @@ public abstract class AbstractWebDriverCore extends AbstractGuiElementCore imple
             File elementScreenshot = new File(viewPortScreenshot.getPath());
             ImageIO.write(eleScreenshot, "png", elementScreenshot);
             return elementScreenshot;
+        } catch (RasterFormatException e) {
+            String message = String.format("Unable to take screenshot from %s. Element seems to be outside of viewport.", guiElementData);
+            throw new RuntimeException(message, e);
         } catch (IOException e) {
-            log().error(String.format("%s unable to take screenshot: %s ", guiElementData, e));
+            final String message = String.format("Unable to take screenshot from %s ", guiElementData);
+            throw new RuntimeException(message, e);
         }
-
-        return null;
     }
 
     // Calculate the global position of an element by going to all parent elements

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/internal/core/AbstractWebDriverCore.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/pageobjects/internal/core/AbstractWebDriverCore.java
@@ -739,7 +739,7 @@ public abstract class AbstractWebDriverCore extends AbstractGuiElementCore imple
             ImageIO.write(eleScreenshot, "png", elementScreenshot);
             return elementScreenshot;
         } catch (RasterFormatException e) {
-            String message = String.format("Unable to take screenshot from %s. Element seems to be outside of viewport.", guiElementData);
+            final String message = String.format("Unable to take screenshot from %s. Element seems to be outside of viewport.", guiElementData);
             throw new RuntimeException(message, e);
         } catch (IOException e) {
             final String message = String.format("Unable to take screenshot from %s ", guiElementData);

--- a/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/playground/DriverAndGuiElementTest.java
+++ b/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/playground/DriverAndGuiElementTest.java
@@ -153,4 +153,16 @@ public class DriverAndGuiElementTest extends AbstractTestSitesTest implements Ui
 
         WEB_DRIVER_MANAGER.getWebDriver(request);
     }
+
+    @Test
+    public void testLayoutCheckOutsideViewport() {
+        WebDriver driver = getWebDriver();
+        UiElementFinder finder = UI_ELEMENT_FINDER_FACTORY.create(driver);
+
+        finder.getWebDriver().get("https://www.telekom.de/start");
+        finder.find(By.id("rejectAll")).click();
+        UiElement uiElement = finder.find(By.xpath("//div[@class='body-container']//section[@class='page_modules_page__3KcU-']//div[@id='PHX_home_r1c1']//p"));
+        uiElement.screenshotToReport();
+
+    }
 }

--- a/integration-tests/src/test/resources/test.properties
+++ b/integration-tests/src/test/resources/test.properties
@@ -1,5 +1,5 @@
-#tt.browser=chromeHeadless
-tt.browser=chrome
+tt.browser=chromeHeadless
+#tt.browser=chrome
 #tt.browser=firefox
 tt.browser.maximize=false
 #tt.browser.maximize=true

--- a/integration-tests/src/test/resources/test.properties
+++ b/integration-tests/src/test/resources/test.properties
@@ -1,5 +1,5 @@
-tt.browser=chromeHeadless
-#tt.browser=chrome
+#tt.browser=chromeHeadless
+tt.browser=chrome
 #tt.browser=firefox
 tt.browser.maximize=false
 #tt.browser.maximize=true


### PR DESCRIPTION
# Description

Minor improvement in exception handling for creating an element screenshot:
- Handling issue when element is outside the viewport
- Handling an `IOException`

In both cases now a `RuntimeException` is thrown to get a readable error message and prevent NPEs on later steps.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
