### PR TITLE
Added fix to handle subfolders in filenames of reference images

### DIFF
--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/layout/LayoutCheck.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/layout/LayoutCheck.java
@@ -49,6 +49,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.HashMap;
 
@@ -128,7 +129,7 @@ public final class LayoutCheck implements PropertyManagerProvider, AssertProvide
      */
     private static MatchStep prepare(
             final Path screenshot,
-            final String targetImageName
+            final String targetImagePath
     ) {
         if (baseDir == null) {
             findRealBaseDir();
@@ -140,6 +141,15 @@ public final class LayoutCheck implements PropertyManagerProvider, AssertProvide
         Path referenceImagesDir = baseDir.resolve(Properties.REFERENCE_PATH.asString());
         Path actualImagesDir = baseDir.resolve(Properties.ACTUAL_PATH.asString());
         Path distanceImagesDir = baseDir.resolve(Properties.DISTANCE_PATH.asString());
+
+        // Check targetImageName for subfolders
+        Path targetImage = Paths.get(targetImagePath);
+        String targetImageName = targetImage.getFileName().toString();
+        if (targetImage.getParent() != null) {
+            referenceImagesDir = referenceImagesDir.resolve(targetImage.getParent());
+            actualImagesDir = actualImagesDir.resolve(targetImage.getParent());
+            distanceImagesDir = distanceImagesDir.resolve(targetImage.getParent());
+        }
 
         FileUtils.createDirectoriesSafely(referenceImagesDir);
         FileUtils.createDirectoriesSafely(actualImagesDir);


### PR DESCRIPTION
# Description

Added fix to handle subfolders in filenames of reference images. Comes with #469.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
