### PR TITLE
Fix the element timeout settings with customs and default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ build
 /report-ng-tests/src/test/resources/screenreferences/distance/
 /report-ng-tests/src/test/resources/screenreferences/actual/
 /integration-tests/geckodriver.exe
+/integration-tests/report-pretest-status/

--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/testing/DefaultTestControllerOverrides.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/testing/DefaultTestControllerOverrides.java
@@ -39,7 +39,7 @@ public class DefaultTestControllerOverrides implements TestController.Overrides 
 
     @Override
     public boolean hasTimeout() {
-        return threadLocalTimeout.get()!=null;
+        return threadLocalTimeout.get() != null;
     }
 
     @Override
@@ -51,7 +51,7 @@ public class DefaultTestControllerOverrides implements TestController.Overrides 
 
     @Override
     public int setTimeout(int seconds) {
-        Integer prevTimeout = getTimeoutInSeconds();
+        int prevTimeout = getTimeoutInSeconds();
         if (seconds < 0) {
             // Back to default
             threadLocalTimeout.remove();

--- a/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/testing/UiElementOverrides.java
+++ b/driver-ui/src/main/java/eu/tsystems/mms/tic/testframework/testing/UiElementOverrides.java
@@ -15,4 +15,19 @@ public class UiElementOverrides extends DefaultTestControllerOverrides {
         }
         return timeoutInSeconds;
     }
+
+    /**
+     * A custom timeout with CONTROL.withTimeout with default settings will be ignored.
+     * Otherwise, the previous timeout (maybe the default) is set as new thread local value in DefaultTestControllerOverrides. But
+     * this has an impact on other custom timeout settings with @PageOptions or @Check.
+     */
+    @Override
+    public int setTimeout(int seconds) {
+        int defaultTimeoutInSeconds = UiElement.Properties.ELEMENT_TIMEOUT_SECONDS.asLong().intValue();
+        if (seconds == defaultTimeoutInSeconds) {
+            return super.setTimeout(-1);
+        } else {
+            return super.setTimeout(seconds);
+        }
+    }
 }

--- a/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/pagefactory/PageOptionsTest.java
+++ b/integration-tests/src/test/java/eu/tsystems/mms/tic/testframework/test/pagefactory/PageOptionsTest.java
@@ -22,9 +22,12 @@
 package eu.tsystems.mms.tic.testframework.test.pagefactory;
 
 import eu.tsystems.mms.tic.testframework.AbstractTestSitesTest;
+import eu.tsystems.mms.tic.testframework.common.Testerra;
 import eu.tsystems.mms.tic.testframework.core.pageobjects.testdata.PageWithCheckTimeout;
 import eu.tsystems.mms.tic.testframework.core.pageobjects.testdata.PageWithExistingElement;
 import eu.tsystems.mms.tic.testframework.core.pageobjects.testdata.PageWithPageOptions;
+import eu.tsystems.mms.tic.testframework.pageobjects.Page;
+import eu.tsystems.mms.tic.testframework.pageobjects.UiElement;
 import eu.tsystems.mms.tic.testframework.testing.AssertProvider;
 import eu.tsystems.mms.tic.testframework.testing.PageFactoryProvider;
 import org.openqa.selenium.WebDriver;
@@ -45,31 +48,57 @@ public class PageOptionsTest extends AbstractTestSitesTest implements PageFactor
     }
 
     @Test
-    public void testPageOptionsTimeout() {
+    public void testT01_PageOptionsTimeout() {
         WebDriver webDriver = getClassExclusiveWebDriver();
-        long start = System.currentTimeMillis();
-        long end = start;
-        try {
-            PAGE_FACTORY.createPage(PageWithPageOptions.class, webDriver);
-        } catch (Throwable throwable) {
-            end = System.currentTimeMillis();
-        }
-
-        ASSERT.assertBetween(end - start, 3000, 3500);
-        log().info("Duration: {}ms", end - start);
+//        CONTROL.withTimeout(8, () -> PAGE_FACTORY.createPage(PageWithExistingElement.class, webDriver));
+        this.runTest(webDriver, PageWithPageOptions.class, 3000, 3500);
     }
 
     @Test
-    public void testCheckTimeout() {
+    public void testT02_PageCheckTimeout() {
         WebDriver webDriver = getClassExclusiveWebDriver();
+        this.runTest(webDriver, PageWithCheckTimeout.class, 3000, 3500);
+    }
+
+    /**
+     * CONTROL.withTimeout() overrides PageOptions timeout
+     */
+    @Test
+    public void testT03_PageOptionsWithControlTimeout() {
+        WebDriver webDriver = getClassExclusiveWebDriver();
+        CONTROL.withTimeout(4, () -> this.runTest(webDriver, PageWithPageOptions.class, 4000, 4500));
+    }
+
+    /**
+     * CONTROL.withTimeout() overrides Check element timeout
+     */
+    @Test
+    public void testT04_PageCheckWithControlTimeout() {
+        WebDriver webDriver = getClassExclusiveWebDriver();
+        CONTROL.withTimeout(4, () -> this.runTest(webDriver, PageWithCheckTimeout.class, 4000, 4500));
+    }
+
+    /**
+     * Setting the default timeout with CONTROL.withTimeout is the same running without CONTROL.withTimeout.
+     * Here: PageWithPageOptions class has 3 seconds, default are 2 seconds.
+     */
+    @Test
+    public void testT05_PageOptionsWithControlTimeoutWithDefault() {
+        int defaultTimeout = UiElement.Properties.ELEMENT_TIMEOUT_SECONDS.asLong().intValue();
+        WebDriver webDriver = getClassExclusiveWebDriver();
+        CONTROL.withTimeout(defaultTimeout, () -> this.runTest(webDriver, PageWithPageOptions.class, 3000, 3500));
+    }
+
+    private <T extends Page> void  runTest(WebDriver webDriver, Class<T> clazz, int minMs, int maxMs) {
         long start = System.currentTimeMillis();
         long end = start;
         try {
-            PAGE_FACTORY.createPage(PageWithCheckTimeout.class, webDriver);
+            PAGE_FACTORY.createPage(clazz, webDriver);
         } catch (Throwable throwable) {
             end = System.currentTimeMillis();
         }
 
-        ASSERT.assertBetween(end - start, 3000, 3500);
+        ASSERT.assertBetween(end - start, minMs, maxMs);
+        log().info("Duration: {}ms", end - start);
     }
 }


### PR DESCRIPTION
# Description

After using `CONTROL.withTimeout()` the timeout setting is reset to the default, but as thread-local. This prevents using custom timeout handling e.g. with `@PageOptions`.
This fix adds an additional check for reset to previous setting. As a result, using `CONTROL.withTimeout()` with default timeout will be ignored.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
