### PR TITLE
Fix/fails validator

### DIFF
--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/execution/testng/worker/finish/MethodContextUpdateWorker.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/execution/testng/worker/finish/MethodContextUpdateWorker.java
@@ -95,23 +95,6 @@ public class MethodContextUpdateWorker implements MethodEndEvent.Listener {
             Optional<Fails> failsAnnotation = methodContext.getFailsAnnotation();
             failsAnnotation.ifPresent(fails -> {
                 boolean isFailsAnnotationValid = this.isFailsAnnotationValid(fails, methodContext, event.getTestMethod());
-
-//                Boolean isFailsAnnotationValid = false;
-
-//                if (!fails.intoReport()) {
-//                    String validatorMethodName = fails.validator();
-//                    if (StringUtils.isNotBlank(validatorMethodName)) {
-//                        try {
-//                            Object validatorInstance = getValidatorInstance(fails).orElse(event.getTestMethod().getInstance());
-//                            Method validatorMethod = validatorInstance.getClass().getMethod(validatorMethodName, MethodContext.class);
-//                            isFailsAnnotationValid = (Boolean) validatorMethod.invoke(validatorInstance, methodContext);
-//                        } catch (Throwable t) {
-//                            methodContext.addError(t);
-//                        }
-//                    } else {
-//                        isFailsAnnotationValid = true;
-//                    }
-//                }
                 if (isFailsAnnotationValid) {
                     methodContext.setStatus(Status.FAILED_EXPECTED);
                 }

--- a/core/src/main/java/eu/tsystems/mms/tic/testframework/execution/testng/worker/finish/MethodContextUpdateWorker.java
+++ b/core/src/main/java/eu/tsystems/mms/tic/testframework/execution/testng/worker/finish/MethodContextUpdateWorker.java
@@ -30,6 +30,7 @@ import eu.tsystems.mms.tic.testframework.report.model.context.ErrorContext;
 import eu.tsystems.mms.tic.testframework.report.model.context.MethodContext;
 import eu.tsystems.mms.tic.testframework.report.model.steps.TestStep;
 import org.apache.commons.lang3.StringUtils;
+import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
 
 import java.lang.reflect.Constructor;
@@ -93,22 +94,24 @@ public class MethodContextUpdateWorker implements MethodEndEvent.Listener {
              */
             Optional<Fails> failsAnnotation = methodContext.getFailsAnnotation();
             failsAnnotation.ifPresent(fails -> {
-                Boolean isFailsAnnotationValid = false;
+                boolean isFailsAnnotationValid = this.isFailsAnnotationValid(fails, methodContext, event.getTestMethod());
 
-                if (!fails.intoReport()) {
-                    String validatorMethodName = fails.validator();
-                    if (StringUtils.isNotBlank(validatorMethodName)) {
-                        try {
-                            Object validatorInstance = getValidatorInstance(fails).orElse(event.getTestMethod().getInstance());
-                            Method validatorMethod = validatorInstance.getClass().getMethod(validatorMethodName, MethodContext.class);
-                            isFailsAnnotationValid = (Boolean) validatorMethod.invoke(validatorInstance, methodContext);
-                        } catch (Throwable t) {
-                            methodContext.addError(t);
-                        }
-                    } else {
-                        isFailsAnnotationValid = true;
-                    }
-                }
+//                Boolean isFailsAnnotationValid = false;
+
+//                if (!fails.intoReport()) {
+//                    String validatorMethodName = fails.validator();
+//                    if (StringUtils.isNotBlank(validatorMethodName)) {
+//                        try {
+//                            Object validatorInstance = getValidatorInstance(fails).orElse(event.getTestMethod().getInstance());
+//                            Method validatorMethod = validatorInstance.getClass().getMethod(validatorMethodName, MethodContext.class);
+//                            isFailsAnnotationValid = (Boolean) validatorMethod.invoke(validatorInstance, methodContext);
+//                        } catch (Throwable t) {
+//                            methodContext.addError(t);
+//                        }
+//                    } else {
+//                        isFailsAnnotationValid = true;
+//                    }
+//                }
                 if (isFailsAnnotationValid) {
                     methodContext.setStatus(Status.FAILED_EXPECTED);
                 }
@@ -123,9 +126,30 @@ public class MethodContextUpdateWorker implements MethodEndEvent.Listener {
             RetryAnalyzer.methodHasBeenPassed(methodContext);
 
             methodContext.getFailsAnnotation().ifPresent(fails -> {
-                methodContext.setStatus(Status.REPAIRED);
+                boolean isFailsAnnotationValid = this.isFailsAnnotationValid(fails, methodContext, event.getTestMethod());
+                if (isFailsAnnotationValid) {
+                    methodContext.setStatus(Status.REPAIRED);
+                }
             });
         }
+    }
+
+    private boolean isFailsAnnotationValid(Fails fails, MethodContext methodContext, ITestNGMethod testMethod) {
+        if (!fails.intoReport()) {
+            String validatorMethodName = fails.validator();
+            if (StringUtils.isNotBlank(validatorMethodName)) {
+                try {
+                    Object validatorInstance = getValidatorInstance(fails).orElse(testMethod.getInstance());
+                    Method validatorMethod = validatorInstance.getClass().getMethod(validatorMethodName, MethodContext.class);
+                    return (Boolean) validatorMethod.invoke(validatorInstance, methodContext);
+                } catch (Throwable t) {
+                    methodContext.addError(t);
+                }
+            } else {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/integration-tests/src/test/java/io/testerra/test/pretest_status/ExpectedFailsTests.java
+++ b/integration-tests/src/test/java/io/testerra/test/pretest_status/ExpectedFailsTests.java
@@ -80,6 +80,11 @@ public class ExpectedFailsTests extends TesterraTest implements TestStatusTest {
     }
 
     @Test(groups = {"ExpectedFailsTests"})
+    @Fails(validator = "failedExpectedIsNotValid")
+    public void test_invalidExpectedFailed_mustPassed() {
+    }
+
+    @Test(groups = {"ExpectedFailsTests"})
     @Fails(validatorClass = ExpectedFailedValidator.class, validator = "failedExpectedIsNotValid")
     public void test_invalidExpectedFailed_withClass() {
         Assert.fail();

--- a/integration-tests/src/test/java/io/testerra/test/pretest_status/ExpectedFailsTests.java
+++ b/integration-tests/src/test/java/io/testerra/test/pretest_status/ExpectedFailsTests.java
@@ -43,6 +43,10 @@ public class ExpectedFailsTests extends TesterraTest implements TestStatusTest {
         return false;
     }
 
+    /**
+     * Normal run --> Expected failed
+     * Dry run --> Repaired
+     */
     @Test(groups = {"ExpectedFailsTests"})
     @Fails
     @Retry(maxRetries = 2)
@@ -50,40 +54,68 @@ public class ExpectedFailsTests extends TesterraTest implements TestStatusTest {
         Assert.fail();
     }
 
+    /**
+     * Normal run --> Expected failed
+     * Dry run --> Repaired
+     */
     @Test(groups = {"ExpectedFailsTests"})
     @Fails
     public void test_expectedFailed() {
         Assert.fail();
     }
 
+    /**
+     * Normal run --> Repaired
+     * Dry run --> Repaired
+     */
     @Test(groups = {"ExpectedFailsTests"})
     @Fails(description = "not failing anymore")
     public void test_expectedFailedPassed() {
     }
 
+    /**
+     * Normal run --> Expected failed
+     * Dry run --> Repaired
+     */
     @Test(groups = {"ExpectedFailsTests"})
     @Fails(validator = "failedExpectedIsValid")
     public void test_validExpectedFailed_withMethod() {
         Assert.fail();
     }
 
+    /**
+     * Normal run --> Failed
+     * Dry run --> Passed
+     */
     @Test(groups = {"ExpectedFailsTests"})
     @Fails(validator = "failedExpectedIsNotValid")
     public void test_invalidExpectedFailed_withMethod() {
         Assert.fail();
     }
 
+    /**
+     * Normal run --> Expected failed
+     * Dry run --> Repaired
+     */
     @Test(groups = {"ExpectedFailsTests"})
     @Fails(validatorClass = ExpectedFailedValidator.class, validator = "failedExpectedIsValid")
     public void test_validExpectedFailed_withClass() {
         Assert.fail();
     }
 
+    /**
+     * Normal run --> Passed
+     * Dry run --> Passed
+     */
     @Test(groups = {"ExpectedFailsTests"})
     @Fails(validator = "failedExpectedIsNotValid")
     public void test_invalidExpectedFailed_mustPassed() {
     }
 
+    /**
+     * Normal run --> Failed
+     * Dry run --> Passed
+     */
     @Test(groups = {"ExpectedFailsTests"})
     @Fails(validatorClass = ExpectedFailedValidator.class, validator = "failedExpectedIsNotValid")
     public void test_invalidExpectedFailed_withClass() {

--- a/integration-tests/src/test/java/io/testerra/test/status/CheckDryRunStatusTest.java
+++ b/integration-tests/src/test/java/io/testerra/test/status/CheckDryRunStatusTest.java
@@ -86,11 +86,11 @@ public class CheckDryRunStatusTest extends TesterraTest {
                 {"*** Stats: SuiteContexts:  3", "SuiteContext"},
                 {"*** Stats: TestContexts:   3", "TestContext"},
                 {"*** Stats: ClassContexts:  17", "ClassContext"},
-                {"*** Stats: MethodContexts: 78", "MethodContexts"},
-                {"*** Stats: Test Methods Count: 51 (51 relevant)", "Test methods"},
+                {"*** Stats: MethodContexts: 79", "MethodContexts"},
+                {"*** Stats: Test Methods Count: 52 (52 relevant)", "Test methods"},
                 {"*** Stats: Failed: 1", "Failed tests"},
                 {"*** Stats: Skipped: 3", "Skipped tests"},
-                {"*** Stats: Passed: 47 ⊃ Repaired: 11", "Passed tests"}
+                {"*** Stats: Passed: 48 ⊃ Repaired: 11", "Passed tests"}
         };
     }
 

--- a/integration-tests/src/test/java/io/testerra/test/status/CheckDryRunStatusTest.java
+++ b/integration-tests/src/test/java/io/testerra/test/status/CheckDryRunStatusTest.java
@@ -90,7 +90,7 @@ public class CheckDryRunStatusTest extends TesterraTest {
                 {"*** Stats: Test Methods Count: 52 (52 relevant)", "Test methods"},
                 {"*** Stats: Failed: 1", "Failed tests"},
                 {"*** Stats: Skipped: 3", "Skipped tests"},
-                {"*** Stats: Passed: 48 ⊃ Repaired: 11", "Passed tests"}
+                {"*** Stats: Passed: 48 ⊃ Repaired: 8", "Passed tests"}
         };
     }
 

--- a/integration-tests/src/test/java/io/testerra/test/status/CheckTestStatusTest.java
+++ b/integration-tests/src/test/java/io/testerra/test/status/CheckTestStatusTest.java
@@ -54,6 +54,7 @@ public class CheckTestStatusTest extends TesterraTest {
                 {"test_invalidExpectedFailed_withMethod", Status.FAILED},
                 {"test_validExpectedFailed_withClass", Status.FAILED_EXPECTED},
                 {"test_invalidExpectedFailed_withClass", Status.FAILED},
+                {"test_invalidExpectedFailed_mustPassed", Status.PASSED},
                 {"testT04_DataProviderWithFailedTests(failed)", Status.FAILED},
                 {"testT04_DataProviderWithFailedTests(passed)", Status.PASSED},
                 {"testT05_DataProviderWithFailedTestsOptional(passed)", Status.PASSED},
@@ -133,13 +134,13 @@ public class CheckTestStatusTest extends TesterraTest {
                 {"*** Stats: SuiteContexts:  3", "SuiteContext"},
                 {"*** Stats: TestContexts:   3", "TestContext"},
                 {"*** Stats: ClassContexts:  17", "ClassContext"},
-                {"*** Stats: MethodContexts: 89", "MethodContexts"},
-                {"*** Stats: Test Methods Count: 62 (51 relevant)", "Test methods"},
+                {"*** Stats: MethodContexts: 90", "MethodContexts"},
+                {"*** Stats: Test Methods Count: 63 (52 relevant)", "Test methods"},
                 {"*** Stats: Failed: 10", "Failed tests"},
                 {"*** Stats: Retried: 11", "Retried tests"},
                 {"*** Stats: Expected Failed: 7", "Expected failed tests"},
                 {"*** Stats: Skipped: 12", "Skipped tests"},
-                {"*** Stats: Passed: 22 ⊃ Recovered: 5 ⊃ Repaired: 1", "Passed tests"}
+                {"*** Stats: Passed: 23 ⊃ Recovered: 5 ⊃ Repaired: 1", "Passed tests"}
         };
     }
 


### PR DESCRIPTION
# Description

Fixed the `@Fails` validator for the following case:
- Test has `@Fails` annotation with validator
- For the current run the fails validator returns false. That means, for the current setting a failed test cannot be a `Expected failed` because some preconditions does not match to validation rules.
- On the other hand, a passed test cannot be `Repaired` but must be `Passed`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
